### PR TITLE
Use placeholders when default credits for local users are disabled

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,7 +116,8 @@ module.exports = function(grunt) {
             dist: {
                 options: {
                     style: 'compressed',
-                    sourcemap: 'none'
+                    sourcemap: 'none',
+                    compass: true
                 },
                 files: [ { expand: true,
 		                   cwd: 'admin/scss',
@@ -132,7 +133,8 @@ module.exports = function(grunt) {
             dev: {
                 options: {
                     style: 'expanded',
-                    sourcemap: 'none'
+                    sourcemap: 'none',
+                    compass: true
                 },
                 files: [ { expand: true,
 		                   cwd: 'admin/scss',

--- a/admin/class-media-credit-admin.php
+++ b/admin/class-media-credit-admin.php
@@ -89,6 +89,11 @@ class Media_Credit_Admin implements Media_Credit_Base {
 		if ( $this->is_media_settings_page() ) {
 			wp_enqueue_style( 'media-credit-preview-style', $this->ressource_url . 'css/media-credit-preview.css', array(), $this->version, 'screen' );
 		}
+
+		// Style placeholders when editing media.
+		if ( $this->is_media_edit_page() ) {
+			wp_enqueue_style( 'media-credit-attachment-details-style', $this->ressource_url . 'css/media-credit-attachment-details.css', array(), $this->version, 'screen' );
+		}
 	}
 
 	/**
@@ -653,13 +658,22 @@ class Media_Credit_Admin implements Media_Credit_Base {
 		$credit    = Media_Credit_Template_Tags::get_media_credit( $attachment );
 		$url       = Media_Credit_Template_Tags::get_media_credit_url( $attachment );
 		$author_id = '' === Media_Credit_Template_Tags::get_freeform_media_credit( $attachment ) ? $attachment->post_author : '';
+		$options   = get_option( self::OPTION );
 
+		// Set up Media Credit model data (not as an array because data-settings code in View can't deal with it.
 		$response['mediaCreditText']                  = $credit;
 		$response['mediaCreditLink']                  = $url;
 		$response['mediaCreditAuthorID']              = $author_id;
 		$response['mediaCreditAuthorDisplay']         = $author_id ? $credit : '';
+
+		// Add some nonces.
 		$response['nonces']['mediaCredit']['update']  = wp_create_nonce( "save-attachment-{$response['id']}-media-credit" );
 		$response['nonces']['mediaCredit']['content'] = wp_create_nonce( "update-attachment-{$response['id']}-media-credit-in-editor" );
+
+		// And the Media Credit options.
+		$response['mediaCreditOptions']['noDefaultCredit']     = $options['no_default_credit'];
+		$response['mediaCreditOptions']['creditAtEnd']         = $options['credit_at_end'];
+		$response['mediaCreditOptions']['postThumbnailCredit'] = $options['post_thumbnail_credit'];
 
 		return $response;
 	}

--- a/admin/css/media-credit-attachment-details.css
+++ b/admin/css/media-credit-attachment-details.css
@@ -1,0 +1,13 @@
+@charset "UTF-8";
+label[data-setting="mediaCreditText"] input[type="text"]:-moz-placeholder {
+      opacity: 0.3;
+}
+label[data-setting="mediaCreditText"] input[type="text"]::-moz-placeholder {
+      opacity: 0.3;
+}
+label[data-setting="mediaCreditText"] input[type="text"]:-ms-input-placeholder {
+      opacity: 0.3;
+}
+label[data-setting="mediaCreditText"] input[type="text"]::-webkit-input-placeholder {
+      opacity: 0.3;
+}

--- a/admin/partials/media-credit-attachment-details-tmpl.php
+++ b/admin/partials/media-credit-attachment-details-tmpl.php
@@ -14,7 +14,12 @@
 ?><script type="text/html" id="tmpl-media-credit-attachment-details">
 	<label class="setting" data-setting="mediaCreditText">
 		<span class="name"><?php esc_html_e( 'Credit', 'media-credit' ); ?></span>
-		<input type="text" class="media-credit-input" value="{{ data.mediaCreditText }}" />
+		<input type="text" class="media-credit-input" <#
+		if ( data.mediaCreditAuthorID && data.mediaCreditOptions.noDefaultCredit ) {
+			#>placeholder<#
+		} else {
+			#>value<#
+		} #>="{{ data.mediaCreditText }}" />
 	</label>
 	<label class="setting" data-setting="mediaCreditLink">
 		<span class="name"><?php esc_html_e( 'Credit URL', 'media-credit' ); ?></span>

--- a/admin/scss/media-credit-attachment-details.scss
+++ b/admin/scss/media-credit-attachment-details.scss
@@ -1,0 +1,7 @@
+@import "compass/css3/user-interface";
+
+label[data-setting="mediaCreditText"] input[type="text"] {
+ @include input-placeholder {
+    opacity: 0.3;
+  }
+}


### PR DESCRIPTION
Use `placeholder` attribute instead of `value` when default credits for blog users are disabled.
