### PR TITLE
Restore add_media_credit_fields/save_media_credit_fields

### DIFF
--- a/admin/css/media-credit-attachment-details.css
+++ b/admin/css/media-credit-attachment-details.css
@@ -11,3 +11,13 @@ label[data-setting="mediaCreditText"] input[type="text"]:-ms-input-placeholder {
 label[data-setting="mediaCreditText"] input[type="text"]::-webkit-input-placeholder {
       opacity: 0.3;
 }
+
+#poststuff table.compat-attachment-fields {
+  width: 100%;
+}
+#poststuff table.compat-attachment-fields td.field {
+  width: 80%;
+}
+#poststuff table.compat-attachment-fields td.field input.media-credit-input {
+  width: 100%;
+}

--- a/admin/js/media-credit-autocomplete.js
+++ b/admin/js/media-credit-autocomplete.js
@@ -1,0 +1,99 @@
+/*
+ ** Properly handle editing credits in the media modal.
+ */
+
+/* globals $mediaCredit: false */
+
+( function( $ ) {
+
+	var mediaCredit = {};
+
+	/**
+     * Install autoselect on the given input fields.
+     *
+     * @param $input  A jQuery object for the input field.
+     * @param $hidden A jQuery object for the hidden field.
+     */
+	mediaCredit.autoCompleteLegacy = function( $input, $hidden ) {
+
+		var updateFreeformCredit = function( credit ) {
+			$hidden.attr( 'value', '' );
+			$hidden.attr( 'data-author-display', credit );
+			$input.attr( 'value', credit );
+		};
+
+		// Target the input element (& return it after for chaining).
+		return $input
+
+		// Add autocomplete.
+		.autocomplete( {
+			autoFocus: true,
+			minLength: 2,
+
+			source: $mediaCredit.names || ( $mediaCredit.names = _.map( $mediaCredit.id, function( value, key ) {
+				return { id: key, value: value, label: value };
+			} ) ),
+
+			select: function( event, ui ) {
+				$hidden.attr( 'value', ui.item.id );
+				$hidden.attr( 'data-author-display', ui.item.value );
+				$input.attr( 'value', ui.item.value );
+
+				return false;
+			},
+
+			response: function( event, ui ) {
+				var credit;
+
+				if ( 0 === ui.content.length ) {
+					credit = $( this ).val();
+
+					if ( credit !== $hidden.attr( 'data-display-author' ) ) {
+						updateFreeformCredit( credit );
+					}
+
+					return false;
+				}
+			},
+
+			open: function() {
+				$( this ).autocomplete( 'widget' ).css( 'z-index', 2000000 );
+
+				return false;
+			}
+		} )
+
+		// Select input field value on click.
+		.click( function() {
+			this.select();
+		} )
+
+		// Handle tab while still loading suggestion.
+		.change( function( event ) {
+			var credit = $input.val(),
+				authorID = $hidden.attr( 'data-author-id' );
+
+			if ( $mediaCredit.noDefaultCredit && '' === credit && '' === $hidden.val() ) {
+				$hidden.val( authorID );
+				$hidden.attr( 'data-author-display', $mediaCredit.id[ authorID ] );
+
+				// Re-set placeholder.
+				$input.val( '' ).attr( 'placeholder', $hidden.attr( 'data-author-display' ) );
+
+				event.stopImmediatePropagation();
+				event.preventDefault();
+			} else if ( credit !== $hidden.attr( 'data-author-display' ) ) {
+				updateFreeformCredit( credit );
+
+				event.stopImmediatePropagation();
+				event.preventDefault();
+			}
+		} );
+	};
+
+	mediaCredit.data   = $( '.media-credit-hidden' ).data();
+	mediaCredit.input  = $( '#attachments\\[' + mediaCredit.data.postId + '\\]\\[media-credit\\]' );
+	mediaCredit.hidden = $( '#attachments\\[' + mediaCredit.data.postId + '\\]\\[media-credit-hidden\\]' );
+	mediaCredit.autoCompleteLegacy( mediaCredit.input, mediaCredit.hidden );
+
+} )( jQuery );

--- a/admin/scss/media-credit-attachment-details.scss
+++ b/admin/scss/media-credit-attachment-details.scss
@@ -5,3 +5,15 @@ label[data-setting="mediaCreditText"] input[type="text"] {
     opacity: 0.3;
   }
 }
+
+#poststuff table.compat-attachment-fields {
+	width: 100%;
+	
+	td.field {
+		width: 80%;
+	
+		input.media-credit-input {
+			width: 100%;
+		}
+	}
+}

--- a/includes/class-media-credit.php
+++ b/includes/class-media-credit.php
@@ -133,6 +133,7 @@ class Media_Credit implements Media_Credit_Base {
 	private function define_admin_hooks() {
 		$plugin_admin = new Media_Credit_Admin( $this->get_plugin_name(), $this->get_version() );
 
+		// Action hooks.
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_action( 'wp_enqueue_editor',     $plugin_admin, 'enqueue_editor', 10, 1 );
@@ -142,10 +143,14 @@ class Media_Credit implements Media_Credit_Base {
 		$this->loader->add_action( 'admin_init',            $plugin_admin, 'admin_init' );
 		$this->loader->add_action( 'customize_controls_enqueue_scripts', $plugin_admin, 'enqueue_media_credit_scripts' );
 
+		// AJAX actions.
 		$this->loader->add_action( 'wp_ajax_update-media-credit-in-post-content', $plugin_admin, 'ajax_filter_content' );
 		$this->loader->add_action( 'wp_ajax_save-attachment-media-credit',        $plugin_admin, 'ajax_save_attachment_media_credit' );
 
+		// Filter hooks.
 		$this->loader->add_filter( 'wp_prepare_attachment_for_js',                  $plugin_admin, 'prepare_attachment_media_credit_for_js', 10, 3 );
+		$this->loader->add_filter( 'attachment_fields_to_edit',                     $plugin_admin, 'add_media_credit_fields',                10, 2 );
+		$this->loader->add_filter( 'attachment_fields_to_save',                     $plugin_admin, 'save_media_credit_fields',               10, 2 );
 		$this->loader->add_filter( 'image_send_to_editor',                          $plugin_admin, 'image_send_to_editor',                   10, 8 );
 		$this->loader->add_filter( 'plugin_action_links_' . $this->plugin_basename, $plugin_admin, 'add_action_links',                       10, 1 );
 	}


### PR DESCRIPTION
The old-style attachment list view does not work with the new JavaScript-based Media API, so we have to restore `Media_Credit_Admin::add_media_credit_fields` and `Media_Credit_Admin::save_media_credit_fields`. At the same time, `Media_Credit_Admin::is_media_edit_page` has been replaced with a more robust solution without the `$pagenow` global.
