### PR TITLE
Create unified media credit write API

### DIFF
--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -27,6 +27,7 @@
 
 namespace Media_Credit;
 
+use Media_Credit\Data_Storage\Cache;
 use Media_Credit\Data_Storage\Options;
 
 /**
@@ -104,6 +105,13 @@ class Core {
 	private $version;
 
 	/**
+	 * The object cache handler.
+	 *
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
 	 * The options handler.
 	 *
 	 * @var Options
@@ -128,11 +136,13 @@ class Core {
 	 * Creates a new instance.
 	 *
 	 * @param string   $version           The plugin version string (e.g. "3.0.0-beta.2").
+	 * @param Cache    $cache             The object cache handler.
 	 * @param Options  $options           The options handler.
 	 * @param Settings $settings_template The default settings template.
 	 */
-	public function __construct( $version, Options $options, Settings $settings_template ) {
+	public function __construct( $version, Cache $cache, Options $options, Settings $settings_template ) {
 		$this->version           = $version;
+		$this->cache             = $cache;
 		$this->options           = $options;
 		$this->settings_template = $settings_template;
 	}

--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -222,11 +222,12 @@ class Core {
 	 * @param int    $image_id  The attachment ID.
 	 * @param int    $author_id The author ID.
 	 * @param string $freeform  The freeform credit.
-	 * @param string $url       The credit URL. Optional. Default ''.
+	 * @param string $url       The credit URL.
+	 * @param bool   $nofollow  The "rel=nofollow" flag.
 	 *
 	 * @return string           The filtered post content.
 	 */
-	public function filter_changed_media_credits( $content, $image_id, $author_id, $freeform, $url = '' ) {
+	public function filter_changed_media_credits( $content, $image_id, $author_id, $freeform, $url, $nofollow ) {
 
 		// Get the image source URL.
 		$src = \wp_get_attachment_image_src( $image_id );
@@ -273,6 +274,13 @@ class Core {
 				$attr['link'] = $url;
 			} else {
 				unset( $attr['link'] );
+			}
+
+			// Update nofollow attribute.
+			if ( ! empty( $url ) && ! empty( $nofollow ) ) {
+				$attr['nofollow'] = true;
+			} else {
+				unset( $attr['nofollow'] );
 			}
 
 			// Start reconstructing the shortcode.

--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -190,25 +190,29 @@ class Core {
 	}
 
 	/**
-	 * If the given media is attached to a post, edit the media-credit info in the attached (parent) post.
+	 * Updates the shortcodes in the attachments parent post to match the arguments.
 	 *
-	 * @param int|\WP_Post $attachment An attachment ID or the corresponding \WP_Post object.
-	 * @param string       $freeform   Credit for attachment with freeform string. Empty if attachment should be credited to the attachment author.
-	 * @param string       $url        Credit URL for linking. Empty means default link for user of this blog, no link for freeform credit.
+	 * @param  \WP_Post $attachment The attachment \WP_Post object.
+	 * @param  int      $user_id  Optional. The new ID of the media item author. Default 0.
+	 * @param  string   $freeform Optional. The new free-fomr credit string (if $user_id is not used). Default ''.
+	 * @param  string   $url      Optional. The new URL the credit should link to. Default ''.
+	 * @param  array    $flags {
+	 *     Optional. An array of flags to modify the rendering of the media credit. Default [].
+	 *
+	 *     @type bool $nofollow Optional. A flag indicating that `rel=nofollow` should be added to the link. Default false.
+	 * }
 	 */
-	public function update_media_credit_in_post( $attachment, $freeform = '', $url = '' ) {
-
-		// Make sure we are dealing with a post object.
-		if ( ! $attachment instanceof \WP_Post ) {
-			$attachment = \get_post( $attachment );
-		}
+	public function update_shortcodes_in_parent_post( \WP_Post $attachment, $user_id = 0, $freeform = '', $url = '', array $flags = [] ) {
 
 		if ( ! empty( $attachment->post_parent ) ) {
 			// Get the parent post of the attachment.
 			$post = \get_post( $attachment->post_parent );
 
+			// Extract flags.
+			$nofollow = ! empty( $flags['nofollow'] );
+
 			// Filter the post's content.
-			$post->post_content = $this->filter_changed_media_credits( $post->post_content, $attachment->ID, (int) $attachment->post_author, $freeform, $url );
+			$post->post_content = $this->filter_changed_media_credits( $post->post_content, $attachment->ID, $user_id, $freeform, $url, $nofollow );
 
 			// Save the filtered content in the database.
 			\wp_update_post( $post );

--- a/includes/media-credit/components/class-rest-api.php
+++ b/includes/media-credit/components/class-rest-api.php
@@ -306,7 +306,8 @@ class REST_API implements \Media_Credit\Component {
 				$params['attachment_id'],
 				$params['author_id'],
 				$params['freeform'],
-				$params['url']
+				$params['url'],
+				$params['nofollow']
 			)
 		);
 

--- a/includes/media-credit/components/class-rest-api.php
+++ b/includes/media-credit/components/class-rest-api.php
@@ -205,7 +205,7 @@ class REST_API implements \Media_Credit\Component {
 	 *
 	 * @return string
 	 */
-	public function sanitize_text_field( $param, \WP_REST_Request $request, $key ) {
+	public function sanitize_text_field( $param, /* @scrutinizer ignore-unused */ \WP_REST_Request $request, /* @scrutinizer ignore-unused */ $key ) {
 		return \sanitize_text_field( $param );
 	}
 
@@ -219,7 +219,7 @@ class REST_API implements \Media_Credit\Component {
 	 *
 	 * @return array|void
 	 */
-	public function prepare_media_credit_fields( $post, $field_name, \WP_REST_Request $request ) {
+	public function prepare_media_credit_fields( $post, /* @scrutinizer ignore-unused */ $field_name, /* @scrutinizer ignore-unused */ \WP_REST_Request $request ) {
 		$attachment = \get_post( $post['id'] );
 		if ( $attachment instanceof \WP_Post ) {
 			return $this->core->get_media_credit_json( $attachment );
@@ -236,7 +236,7 @@ class REST_API implements \Media_Credit\Component {
 	 *
 	 * @return bool
 	 */
-	public function update_media_credit_fields( $value, \WP_Post $post, $field_name, \WP_REST_Request $request ) {
+	public function update_media_credit_fields( $value, \WP_Post $post, /* @scrutinizer ignore-unused */ $field_name, /* @scrutinizer ignore-unused */ \WP_REST_Request $request ) {
 		if ( empty( $value['raw'] ) ) {
 			return false;
 		}

--- a/includes/media-credit/data-storage/class-cache.php
+++ b/includes/media-credit/data-storage/class-cache.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of Media Credit.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/media-credit
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Media_Credit\Data_Storage;
+
+/**
+ * A plugin-specific cache handler.
+ *
+ * @since 3.3.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Cache extends \Mundschenk\Data_Storage\Cache {
+	const PREFIX = 'media_credit_';
+	const GROUP  = 'media-credit';
+
+	/**
+	 * Creates a new instance.
+	 */
+	public function __construct() {
+		parent::__construct( self::PREFIX, self::GROUP );
+	}
+}


### PR DESCRIPTION
- Use a single entry point in `\Media_Credit\Core` to update the media credit fields.
- Add caching for getting/setting the media credit fields.