### PR TITLE
Customizable placeholders

### DIFF
--- a/admin/js/media-credit-attachment-details.js
+++ b/admin/js/media-credit-attachment-details.js
@@ -99,7 +99,7 @@ jQuery( function( $ ) {
 				}
 
 				// Re-set placeholder.
-				$input.val( '' ).attr( 'placeholder', view.model.get( 'mediaCreditAuthorDisplay' ) );
+				$input.val( '' ).attr( 'placeholder', view.model.get( 'mediaCredit.placeholder' ) );
 
 				event.stopImmediatePropagation();
 				event.preventDefault();
@@ -140,7 +140,7 @@ jQuery( function( $ ) {
 
 					// Re-set placeholder.
 					if ( '' !== this.model.get( 'mediaCreditAuthorID' ) ) {
-						$input.val( '' ).attr( 'placeholder', this.model.get( 'mediaCreditAuthorDisplay' ) );
+						$input.val( '' ).attr( 'placeholder', this.model.get( 'mediaCredit.placeholder' ) );
 					}
 				} else {
 					$input.autocomplete( 'enable' );

--- a/admin/partials/media-credit-attachment-details-tmpl.php
+++ b/admin/partials/media-credit-attachment-details-tmpl.php
@@ -14,12 +14,12 @@
 ?><script type="text/html" id="tmpl-media-credit-attachment-details">
 	<label class="setting" data-setting="mediaCreditText">
 		<span class="name"><?php esc_html_e( 'Credit', 'media-credit' ); ?></span>
-		<input type="text" class="media-credit-input" <#
-		if ( data.mediaCreditAuthorID && data.mediaCreditOptions.noDefaultCredit ) {
-			#>placeholder<#
-		} else {
-			#>value<#
-		} #>="{{ data.mediaCreditText }}" />
+		<input type="text" class="media-credit-input"
+			<# if ( $mediaCredit.noDefaultCredit ) { #>
+				placeholder="{{ data.mediaCredit.placeholder }}"
+			<# } #>
+			value="{{ data.mediaCreditText }}"
+		/>
 	</label>
 	<label class="setting" data-setting="mediaCreditLink">
 		<span class="name"><?php esc_html_e( 'Credit URL', 'media-credit' ); ?></span>

--- a/includes/media-credit/components/class-media-library.php
+++ b/includes/media-credit/components/class-media-library.php
@@ -236,7 +236,10 @@ class Media_Library implements \Media_Credit\Component {
 		$response['mediaCreditAuthorDisplay'] = $response['mediaCreditAuthorID'] ? \get_the_author_meta( 'display_name',  /* @scrutinizer ignore-type */ $response['mediaCreditAuthorID'] ) : '';
 		$response['mediaCreditNoFollow']      = ! empty( $credit['raw']['flags']['nofollow'] ) ? '1' : '0';
 
-		// Add some nonces.
+		// Additional data that's not directly related to the fields.
+		$response['mediaCredit']['placeholder'] = $this->get_placeholder_text( $attachment );
+
+		// We need some nonces as well.
 		$response['nonces']['mediaCredit']['update']  = wp_create_nonce( "save-attachment-{$response['id']}-media-credit" );
 		$response['nonces']['mediaCredit']['content'] = wp_create_nonce( "update-attachment-{$response['id']}-media-credit-in-editor" );
 
@@ -328,5 +331,28 @@ class Media_Library implements \Media_Credit\Component {
 		$this->core->update_media_credit_json( \get_post( $post['ID'] ), $fields );
 
 		return $post;
+	}
+
+	/**
+	 * Retrieves the placeholder text to use for the given attachemnt.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param  \WP_Post $attachment The attachment \WP_Post object.
+	 *
+	 * @return string
+	 */
+	protected function get_placeholder_text( \WP_Post $attachment ) {
+
+		// The default placeholder for credit input fields.
+		$placeholder = \__( 'e.g. Jane Doe', 'media-credit' );
+
+		/**
+		 * Filters the placeholder text for the credit input field.
+		 *
+		 * @param string   $placeholder The placeholder text.
+		 * @param \WP_Post $attachment  The attachment \WP_Post object.
+		 */
+		return \apply_filters( 'media_credit_placeholder_text', $placeholder, $attachment );
 	}
 }


### PR DESCRIPTION
Use translated string as the default placeholder (instead of the attachment's `post_author`) and provide a new filter hook (`media_credit_placeholder_text`) to customize the placeholder attribute further.

Fixes #48.