### PR TITLE
Release 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog #
 
+## 4.0.2 (Mar. 18, 2019) ##
+*   _Bugfix_: Don't whitescreen when the shortcode handler is called with an empty
+    string instead of argument array.
+*   _Bugfix_: Featured images can be set normally again when
+    `Do not credit images to WordPress users` is enabled.
+
 ## 4.0.1 (Mar. 11, 2019) ##
 *   _Bugfix_: Uploads via the Edit Post or New Post screens should work again.
 

--- a/admin/partials/media-credit-attachment-details-tmpl.php
+++ b/admin/partials/media-credit-attachment-details-tmpl.php
@@ -15,7 +15,7 @@
 	<label class="setting" data-setting="mediaCreditText">
 		<span class="name"><?php esc_html_e( 'Credit', 'media-credit' ); ?></span>
 		<input type="text" class="media-credit-input"
-			<# if ( ! data.uploading && mundschenk.mediaCredit.options.noDefaultCredit ) { #>
+			<# if ( data.mediaCredit && mundschenk.mediaCredit.options.noDefaultCredit ) { #>
 				placeholder="{{ data.mediaCredit.placeholder }}"
 			<# } #>
 			value="{{ data.mediaCreditText }}"

--- a/includes/media-credit/components/class-shortcodes.php
+++ b/includes/media-credit/components/class-shortcodes.php
@@ -230,7 +230,8 @@ class Shortcodes implements \Media_Credit\Component {
 			return \do_shortcode( $content );
 		}
 
-		$atts = $this->sanitize_attributes( $atts );
+		// Make sure that $atts really is an array, might be an empty string in some edge cases.
+		$atts = $this->sanitize_attributes( empty( $atts ) ? [] : $atts );
 
 		/**
 		 * Filters the `[media-credit]` shortcode to allow plugins and themes to

--- a/media-credit.php
+++ b/media-credit.php
@@ -28,7 +28,7 @@
  * Plugin Name: Media Credit
  * Plugin URI: https://code.mundschenk.at/media-credit/
  * Description: This plugin adds a "Credit" field to the media uploading and editing tool and inserts this credit when the images appear on your blog.
- * Version: 4.0.1
+ * Version: 4.0.2
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at/
  * License: GNU General Public License v2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: media, image, images, credit, byline, author, user
 Requires at least: 5.0
 Requires PHP: 5.6
 Tested up to: 5.1
-Stable tag: 4.0.1
+Stable tag: 4.0.2
 License: GPLv2 or later
 
 Adds a "Credit" field when uploading media to posts and displays it under the images on your blog to properly credit the artist.
@@ -85,6 +85,10 @@ Feel free to get in touch with us about anything you'd like us to add to this li
 
 
 == Changelog ==
+
+= 4.0.2 (Mar. 18, 2019) =
+* _Bugfix_: Don't whitescreen when the shortcode handler is called with an empty string instead of argument array.
+* _Bugfix_: Featured images can be set normally again when `Do not credit images to WordPress users` is enabled.
 
 = 4.0.1 (Mar. 11, 2019) =
 * _Bugfix_: Uploads via the Edit Post or New Post screens should work again.


### PR DESCRIPTION
- Fixes issue with empty string being passed by `do_shortcode_tag`.
- Generalizes workaround for incomplete JS data in some media modal situations.
- Bumps version to 4.0.2.