### PR TITLE
Release 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog #
 
+## 4.0.3 (Mar. 20, 2019) ##
+*   _Bugfix_: Print credit for featured images, not for the parent post.
+*   _Bugfix_: Slightly improved compatibility with responsive themes (by using 
+    `max-width` instead of `width`).
+
 ## 4.0.2 (Mar. 18, 2019) ##
 *   _Bugfix_: Don't whitescreen when the shortcode handler is called with an empty
     string instead of argument array.

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,13 @@
         "files": ["includes/media-credit-template.php"]
     },
 
+    "config": {
+        "classmap-authoritative": false,
+        "classloader-suffix": "MediaCredit",
+        "autoloader-suffix": "MediaCredit",
+        "process-timeout": 0
+    },
+
     "minimum-stability": "dev",
     "prefer-stable": true,
 

--- a/includes/media-credit/components/class-frontend.php
+++ b/includes/media-credit/components/class-frontend.php
@@ -274,7 +274,7 @@ class Frontend implements \Media_Credit\Component {
 		// Set optional style attribute.
 		$style = '';
 		if ( ! empty( $credit_width ) ) {
-			$style = ' style="width: ' . (int) $credit_width . 'px"';
+			$style = ' style="max-width: ' . (int) $credit_width . 'px"';
 		}
 
 		// Return styled & wrapped credit markup.

--- a/includes/media-credit/components/class-frontend.php
+++ b/includes/media-credit/components/class-frontend.php
@@ -234,7 +234,7 @@ class Frontend implements \Media_Credit\Component {
 		}
 
 		// Retrieve the attachment.
-		$attachment = \get_post( $post_id );
+		$attachment = \get_post( $post_thumbnail_id );
 
 		// Abort if the post ID does not correspond to a valid attachment.
 		if ( ! $attachment instanceof \WP_Post ) {

--- a/media-credit.php
+++ b/media-credit.php
@@ -28,7 +28,7 @@
  * Plugin Name: Media Credit
  * Plugin URI: https://code.mundschenk.at/media-credit/
  * Description: This plugin adds a "Credit" field to the media uploading and editing tool and inserts this credit when the images appear on your blog.
- * Version: 4.0.2
+ * Version: 4.0.3
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at/
  * License: GNU General Public License v2 or later

--- a/public/partials/media-credit-shortcode.php
+++ b/public/partials/media-credit-shortcode.php
@@ -26,7 +26,7 @@
  */
 
 // Apply credit width via style attribute.
-$style = $width > 0 ? ' style="width: ' . (int) $width . 'px"' : '';
+$style = $width > 0 ? ' style="max-width: ' . (int) $width . 'px"' : '';
 
 // Alignment class.
 $align_class = "align{$atts['align']}";

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: media, image, images, credit, byline, author, user
 Requires at least: 5.0
 Requires PHP: 5.6
 Tested up to: 5.1
-Stable tag: 4.0.2
+Stable tag: 4.0.3
 License: GPLv2 or later
 
 Adds a "Credit" field when uploading media to posts and displays it under the images on your blog to properly credit the artist.
@@ -85,6 +85,10 @@ Feel free to get in touch with us about anything you'd like us to add to this li
 
 
 == Changelog ==
+
+= 4.0.3 (Mar. 20, 2019) =
+* _Bugfix_: Print credit for featured images, not for the parent post.
+* _Bugfix_: Slightly improved compatibility with responsive themes (by using `max-width` instead of `width`).
 
 = 4.0.2 (Mar. 18, 2019) =
 * _Bugfix_: Don't whitescreen when the shortcode handler is called with an empty string instead of argument array.


### PR DESCRIPTION
- Print correct credit for featured images, not for the parent post (fixes #71).
- Slightly improves compatibility with responsive themes (by using `max-width` instead of `width`).