### PR TITLE
Release 4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog #
 
+## 4.0.4 (May 19, 2019) ##
+*   _Bugfix_: Prevent PHP warning for incomplete `core/image` blocks.
+
 ## 4.0.3 (Mar. 20, 2019) ##
 *   _Bugfix_: Print credit for featured images, not for the parent post.
-*   _Bugfix_: Slightly improved compatibility with responsive themes (by using 
+*   _Bugfix_: Slightly improved compatibility with responsive themes (by using
     `max-width` instead of `width`).
 
 ## 4.0.2 (Mar. 18, 2019) ##

--- a/includes/media-credit/components/class-block-editor.php
+++ b/includes/media-credit/components/class-block-editor.php
@@ -82,7 +82,7 @@ class Block_Editor implements \Media_Credit\Component {
 		$s = $this->core->get_settings();
 
 		// We only target standard images, and only when the credits are not displayed after the post content.
-		if ( 'core/image' !== $block['blockName'] || ! empty( $s[ Settings::CREDIT_AT_END ] ) ) {
+		if ( 'core/image' !== $block['blockName'] || ! empty( $s[ Settings::CREDIT_AT_END ] ) || ! isset( $block['attrs']['id'] ) ) {
 			return $block_content;
 		}
 

--- a/media-credit.php
+++ b/media-credit.php
@@ -28,7 +28,7 @@
  * Plugin Name: Media Credit
  * Plugin URI: https://code.mundschenk.at/media-credit/
  * Description: This plugin adds a "Credit" field to the media uploading and editing tool and inserts this credit when the images appear on your blog.
- * Version: 4.0.3
+ * Version: 4.0.4
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at/
  * License: GNU General Public License v2 or later

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "media-credit",
   "devDependencies": {
-    "autoprefixer": "^9.4.10",
+    "autoprefixer": "^9.5.1",
     "eslint-config-wordpress": "^2.0.0",
-    "grunt": "^1.0.3",
+    "grunt": "^1.0.4",
     "grunt-cli": "^1.3.2",
     "grunt-composer": "^0.4",
     "grunt-contrib-clean": "^2.0",
     "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-uglify": "^4.0",
+    "grunt-contrib-uglify": "^4.0.1",
     "grunt-eslint": "^21.0.0",
     "grunt-newer": "^1.2.0",
     "grunt-phpcs": "^0.4.0",
@@ -19,7 +19,7 @@
     "grunt-wp-deploy": "^2.0",
     "jshint-stylish": "^2.2.1",
     "load-grunt-tasks": "^4.0",
-    "node-sass": "^4",
+    "node-sass": "^4.12.0",
     "pixrem": "^5.0"
   },
   "browserslist": [

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: pputzer, sbressler
 Tags: media, image, images, credit, byline, author, user
 Requires at least: 5.0
 Requires PHP: 5.6
-Tested up to: 5.1
-Stable tag: 4.0.3
+Tested up to: 5.2
+Stable tag: 4.0.4
 License: GPLv2 or later
 
 Adds a "Credit" field when uploading media to posts and displays it under the images on your blog to properly credit the artist.
@@ -85,6 +85,9 @@ Feel free to get in touch with us about anything you'd like us to add to this li
 
 
 == Changelog ==
+
+= 4.0.4 (May 19, 2019) =
+* _Bugfix_: Prevent PHP warning for incomplete `core/image` blocks.
 
 = 4.0.3 (Mar. 20, 2019) =
 * _Bugfix_: Print credit for featured images, not for the parent post.


### PR DESCRIPTION
- _Bugfix_: Prevent PHP warning for incomplete `core/image` blocks.
