### PR TITLE
Fix JavaScript error in Gutenberg's Classic mode

### DIFF
--- a/includes/media-credit/components/class-block-editor.php
+++ b/includes/media-credit/components/class-block-editor.php
@@ -89,6 +89,7 @@ class Block_Editor implements \Media_Credit\Component {
 		// Retrieve image.
 		$attachment = \get_post( $block['attrs']['id'] );
 		if ( ! $attachment instanceof \WP_Post ) {
+			// Not a valid attachment, let's bail.
 			return $block_content;
 		}
 
@@ -96,9 +97,13 @@ class Block_Editor implements \Media_Credit\Component {
 
 		// Load the media credit for the attachment.
 		$credit = $this->core->get_media_credit_json( $attachment );
-		$markup = $this->core->wrap_media_credit_markup( $credit['rendered'], $include_schema_org );
+		if ( empty( $credit['rendered'] ) ) {
+			// No credit to display, let's bail.
+			return $block_content;
+		}
 
 		// Inject the (modified) caption markup.
+		$markup        = $this->core->wrap_media_credit_markup( $credit['rendered'], $include_schema_org );
 		$block_content = $this->inject_credit_into_caption( $block_content, $markup );
 
 		// Inject additional schema.org markup.

--- a/media-credit.php
+++ b/media-credit.php
@@ -28,7 +28,7 @@
  * Plugin Name: Media Credit
  * Plugin URI: https://code.mundschenk.at/media-credit/
  * Description: This plugin adds a "Credit" field to the media uploading and editing tool and inserts this credit when the images appear on your blog.
- * Version: 4.0.4
+ * Version: 4.1.0-alpha.1
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at/
  * License: GNU General Public License v2 or later


### PR DESCRIPTION
See https://wordpress.org/support/topic/javascript-error-when-using-classic-mode-and-post-containing-credit/ for details.