### PR TITLE
Make attachment details input fields read-only when user lacks write permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.1.0 (unreleased) ##
 *   _Bugfix_: No markup is added to `core/image` blocks when no credit is set.
+*   _Bugfix_: Attachment details input fields are set to read-only when the user
+    lacks write permissions for the image.
 
 ## 4.0.4 (May 19, 2019) ##
 *   _Bugfix_: Prevent PHP warning for incomplete `core/image` blocks.

--- a/admin/partials/media-credit-attachment-details-tmpl.php
+++ b/admin/partials/media-credit-attachment-details-tmpl.php
@@ -12,6 +12,7 @@
  */
 
 ?><script type="text/html" id="tmpl-media-credit-attachment-details">
+	<# var maybeReadOnly = data.can.save || data.allowLocalEdits ? '' : 'readonly'; #>
 	<label class="setting" data-setting="mediaCreditText">
 		<span class="name"><?php esc_html_e( 'Credit', 'media-credit' ); ?></span>
 		<input type="text" class="media-credit-input"
@@ -19,17 +20,19 @@
 				placeholder="{{ data.mediaCredit.placeholder }}"
 			<# } #>
 			value="{{ data.mediaCreditText }}"
+			{{ maybeReadOnly }}
 		/>
 	</label>
 	<label class="setting" data-setting="mediaCreditLink">
 		<span class="name"><?php esc_html_e( 'Credit URL', 'media-credit' ); ?></span>
-		<input type="url" value="{{ data.mediaCreditLink }}" />
+		<input type="url" value="{{ data.mediaCreditLink }}" {{ maybeReadOnly }} />
 	</label>
 	<label class="setting" data-setting="mediaCreditNoFollow">
 		<input type="checkbox" value="{{ data.mediaCreditNoFollow }}"
 			<# if ( '1' === data.mediaCreditNoFollow ) { #>
 				checked="checked"
 			<# } #>
+			{{ maybeReadOnly }}
 		/>
 		<?php
 			echo wp_kses( __( 'Add <code>rel="nofollow"</code>.', 'media-credit' ), [ 'code' => [] ] );

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,7 @@ Feel free to get in touch with us about anything you'd like us to add to this li
 
 = 4.1.0 (unreleased) =
 * _Bugfix_: No markup is added to `core/image` blocks when no credit is set.
+* _Bugfix_: Attachment details input fields are set to read-only when the user lacks write permissions for the image.
 
 = 4.0.4 (May 19, 2019) =
 * _Bugfix_: Prevent PHP warning for incomplete `core/image` blocks.


### PR DESCRIPTION
Fixes #84.