### PR TITLE
Require at least WordPress 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=7.0.0",
         "level-2/dice": "dev-php8 as 4.0.2",
-        "mundschenk-at/check-wp-requirements": "^1.0",
+        "mundschenk-at/check-wp-requirements": "^2.0",
         "mundschenk-at/wp-data-storage": "^1.0",
         "mundschenk-at/wp-settings-ui": "^1.0"
     },

--- a/includes/class-media-credit-factory.php
+++ b/includes/class-media-credit-factory.php
@@ -34,8 +34,6 @@ use Media_Credit\Tools;
 
 use Mundschenk\Data_Storage;
 
-use RuntimeException;
-
 /**
  * A factory for creating Media_Credit instances via dependency injection.
  *
@@ -78,7 +76,7 @@ class Media_Credit_Factory extends Dice {
 			$factory = new static();
 			$factory = $factory->addRules( $factory->get_rules() );
 
-			if ( $factory instanceof Factory ) {
+			if ( $factory instanceof Media_Credit_Factory ) {
 				self::$factory = $factory;
 			} else {
 				throw new RuntimeException( 'Could not create object factory.' ); // @codeCoverageIgnore
@@ -169,14 +167,14 @@ class Media_Credit_Factory extends Dice {
 	 */
 	protected function get_components() {
 		return [
-			[ 'instance' => Components\Setup::class ],
-			[ 'instance' => Components\Frontend::class ],
-			[ 'instance' => Components\Shortcodes::class ],
-			[ 'instance' => Components\Block_Editor::class ],
-			[ 'instance' => Components\Classic_Editor::class ],
-			[ 'instance' => Components\Media_Library::class ],
-			[ 'instance' => Components\Settings_Page::class ],
-			[ 'instance' => Components\REST_API::class ],
+			[ Dice::INSTANCE => Components\Setup::class ],
+			[ Dice::INSTANCE => Components\Frontend::class ],
+			[ Dice::INSTANCE => Components\Shortcodes::class ],
+			[ Dice::INSTANCE => Components\Block_Editor::class ],
+			[ Dice::INSTANCE => Components\Classic_Editor::class ],
+			[ Dice::INSTANCE => Components\Media_Library::class ],
+			[ Dice::INSTANCE => Components\Settings_Page::class ],
+			[ Dice::INSTANCE => Components\REST_API::class ],
 		];
 	}
 }

--- a/includes/media-credit/class-requirements.php
+++ b/includes/media-credit/class-requirements.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of Media Credit.
+ *
+ * Copyright 2021 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/media-credit
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Media_Credit;
+
+/**
+ * A custom requirements class to check for additional PHP packages and other
+ * prerequisites.
+ *
+ * @since 4.2.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Requirements extends \Mundschenk\WP_Requirements {
+
+	const REQUIREMENTS = [
+		'php'       => '7.0.0',
+		'multibyte' => false,
+		'utf-8'     => false,
+	];
+
+	/**
+	 * Creates a new requirements instance.
+	 */
+	public function __construct() {
+		parent::__construct( 'Media Credit', \MEDIA_CREDIT_PLUGIN_FILE, 'media-credit', self::REQUIREMENTS );
+	}
+}

--- a/media-credit.php
+++ b/media-credit.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Media Credit.
  *
- * Copyright 2013-2020 Peter Putzer.
+ * Copyright 2013-2021 Peter Putzer.
  * Copyright 2010-2011 Scott Bressler.
  *
  * This program is free software; you can redistribute it and/or
@@ -36,21 +36,23 @@
  * Text Domain: media-credit
  */
 
+namespace Media_Credit;
+
 // Don't do anything if called directly.
-if ( ! defined( 'ABSPATH' ) || ! defined( 'WPINC' ) ) {
+if ( ! \defined( 'ABSPATH' ) || ! defined( 'WPINC' ) ) {
 	die();
 }
 
 // Make plugin file path available globally.
-if ( ! defined( 'MEDIA_CREDIT_PLUGIN_FILE' ) ) {
-	define( 'MEDIA_CREDIT_PLUGIN_FILE', __FILE__ );
+if ( ! \defined( 'MEDIA_CREDIT_PLUGIN_FILE' ) ) {
+	\define( 'MEDIA_CREDIT_PLUGIN_FILE', __FILE__ );
 }
-if ( ! defined( 'MEDIA_CREDIT_PLUGIN_PATH' ) ) {
-	define( 'MEDIA_CREDIT_PLUGIN_PATH', dirname( __FILE__ ) );
+if ( ! \defined( 'MEDIA_CREDIT_PLUGIN_PATH' ) ) {
+	\define( 'MEDIA_CREDIT_PLUGIN_PATH', __DIR__ );
 }
 
-// Load requirements class in a PHP 5.2 compatible manner.
-require_once dirname( __FILE__ ) . '/vendor/mundschenk-at/check-wp-requirements/class-mundschenk-wp-requirements.php';
+// Initialize autoloader.
+require_once __DIR__ . '/vendor/autoload.php';
 
 /**
  * Begins execution of the plugin.
@@ -63,21 +65,10 @@ require_once dirname( __FILE__ ) . '/vendor/mundschenk-at/check-wp-requirements/
  * @since 4.0.0 Renamed to media_credit_run
  */
 function media_credit_run() {
-	// Define our requirements.
-	$reqs = array(
-		'php'       => '5.6.0',
-		'multibyte' => false,
-		'utf-8'     => false,
-	);
-
 	// Validate the requirements.
-	$requirements = new Mundschenk_WP_Requirements( 'Media Credit', __FILE__, 'media-credit', $reqs );
-	if ( $requirements->check() ) {
-		// Autoload the rest of our classes.
-		require_once __DIR__ . '/vendor/autoload.php'; // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_dirFound
-
+	if ( ( new Requirements() )->check() ) {
 		// Create and start the plugin.
-		$plugin = Media_Credit_Factory::get()->create( 'Media_Credit\Controller' );
+		$plugin = \Media_Credit_Factory::get()->create( Controller::class );
 		$plugin->run();
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Media Credit ===
 Contributors: pputzer, sbressler
 Tags: media, image, images, credit, byline, author, user
-Requires at least: 5.0
+Requires at least: 5.2
 Requires PHP: 7.0
-Tested up to: 5.6
+Tested up to: 5.7
 Stable tag: 4.1.1
 License: GPLv2 or later
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Media Credit.
  *
- * Copyright 2019-2020 Peter Putzer.
+ * Copyright 2019-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,21 +24,25 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+namespace Media_Credit;
+
+use Media_Credit\Components\Uninstallation;
+
 // Don't do anything if called directly.
-if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+if ( ! \defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	die();
 }
 
 // Make plugin file path available globally (even if we probably don't need it during uninstallaton).
-if ( ! defined( 'MEDIA_CREDIT_PLUGIN_FILE' ) ) {
-	define( 'MEDIA_CREDIT_PLUGIN_FILE', dirname( __FILE__ ) . '/media-credit.php' );
+if ( ! \defined( 'MEDIA_CREDIT_PLUGIN_FILE' ) ) {
+	\define( 'MEDIA_CREDIT_PLUGIN_FILE', \dirname( __FILE__ ) . '/media-credit.php' );
 }
-if ( ! defined( 'MEDIA_CREDIT_PLUGIN_PATH' ) ) {
-	define( 'MEDIA_CREDIT_PLUGIN_PATH', dirname( __FILE__ ) );
+if ( ! \defined( 'MEDIA_CREDIT_PLUGIN_PATH' ) ) {
+	\define( 'MEDIA_CREDIT_PLUGIN_PATH', __DIR__ );
 }
 
-// Load requirements class in a PHP 5.2 compatible manner.
-require_once dirname( __FILE__ ) . '/vendor/mundschenk-at/check-wp-requirements/class-mundschenk-wp-requirements.php';
+// Initialize autoloader.
+require_once __DIR__ . '/vendor/autoload.php';
 
 /**
  * Uninstall the plugin after checking for the necessary PHP version.
@@ -46,22 +50,10 @@ require_once dirname( __FILE__ ) . '/vendor/mundschenk-at/check-wp-requirements/
  * It's necessary to do this here because our classes rely on namespaces.
  */
 function media_credit_uninstall() {
-	// Define our requirements.
-	$reqs = array(
-		'php'       => '5.6.0',
-		'multibyte' => false,
-		'utf-8'     => false,
-	);
-
 	// Validate the requirements.
-	$requirements = new Mundschenk_WP_Requirements( 'Media Credit', __FILE__, 'media-credit', $reqs );
-
-	if ( $requirements->check() ) {
-		// Autoload the rest of your classes.
-		require_once __DIR__ . '/vendor/autoload.php'; // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_dirFound
-
+	if ( ( new Requirements() )->check() ) {
 		// Create and start the uninstallation handler.
-		$uninstaller = Media_Credit_Factory::get()->create( 'Media_Credit\Components\Uninstallation' );
+		$uninstaller = \Media_Credit_Factory::get()->create( Uninstallation::class );
 		$uninstaller->run();
 	}
 }


### PR DESCRIPTION
- Adds WordPress as the minimum version.
- Updates `mundschenk-at/check-wp-requirements` to version 2.0.
- Fixes `Dice` rules to use 4.x syntax.