### PR TITLE
Refactor Settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,10 @@
 
     "autoload": {
         "classmap": ["includes/", "public/", "admin/"],
-        "files": ["includes/media-credit-template.php"],
+        "files": ["includes/media-credit-template.php"]
+    },
+    "autoload-dev": {
+        "classmap": ["tests/" ],
         "exclude-from-classmap": ["tests/phpstan/"]
     },
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,9 @@
         "mundschenk-at/phpunit-cross-version": "dev-master",
         "phpstan/phpstan": "^0.12.81",
         "szepeviktor/phpstan-wordpress": "^0.7.4",
-        "php-stubs/wp-cli-stubs": "^2.4"
+        "php-stubs/wp-cli-stubs": "^2.4",
+        "sirbrillig/phpcs-variable-analysis": "^2.11",
+        "sirbrillig/phpcs-import-detection": "^1.3"
     },
 
     "autoload": {

--- a/includes/class-media-credit-factory.php
+++ b/includes/class-media-credit-factory.php
@@ -31,6 +31,7 @@ use Media_Credit\Controller;
 use Media_Credit\Component;
 use Media_Credit\Components;
 use Media_Credit\Tools;
+use Media_Credit\Settings;
 
 use Mundschenk\Data_Storage;
 
@@ -105,7 +106,8 @@ class Media_Credit_Factory extends Dice {
 		// Define rules.
 		$rules = [
 			// Core API.
-			Core::class                         => [
+			Core::class                         => self::SHARED,
+			Settings::class                     => [
 				'shared'          => true,
 				'constructParams' => [ $version ],
 			],

--- a/includes/class-media-credit-factory.php
+++ b/includes/class-media-credit-factory.php
@@ -133,7 +133,6 @@ class Media_Credit_Factory extends Dice {
 			Components\Frontend::class          => $version_rule,
 			Components\Media_Library::class     => $version_rule,
 			Components\Settings_Page::class     => $version_rule,
-			Components\Setup::class             => $version_rule,
 		];
 
 		return $rules;

--- a/includes/class-media-credit.php
+++ b/includes/class-media-credit.php
@@ -266,9 +266,10 @@ class Media_Credit {
 		}
 
 		// Extract variables for template.
-		$sidebar             = $args['sidebar'];
+		$sidebar             = $args['sidebar']; // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- needed for partial
 		$link_without_parent = $args['link_without_parent'];
 		$header              = $args['header'];
+		// phpcs:enable
 
 		// Load the template part.
 		require \MEDIA_CREDIT_PLUGIN_PATH . '/public/partials/author-media.php';

--- a/includes/media-credit/class-controller.php
+++ b/includes/media-credit/class-controller.php
@@ -26,7 +26,8 @@
 
 namespace Media_Credit;
 
-use Media_Credit\Component;
+use Media_Credit\Component; // phpcs:ignore ImportDetection.Imports.RequireImports -- needed for type annotations.
+use Media_Credit\Core;
 
 /**
  * Initializes Media Credit plugin.

--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -27,11 +27,12 @@
 
 namespace Media_Credit;
 
+use Media_Credit\Settings;
+
 use Media_Credit\Tools\Media_Query;
 use Media_Credit\Tools\Shortcodes_Filter;
 
 use Media_Credit\Data_Storage\Cache;
-use Media_Credit\Data_Storage\Options;
 
 /**
  * The main API for the Media Credit plugin. To allow for static template functions,

--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -101,37 +101,17 @@ class Core {
 	private static $instance;
 
 	/**
-	 * The plugin version.
-	 *
-	 * @var string
-	 */
-	private $version;
-
-	/**
 	 * The object cache handler.
 	 *
 	 * @var Cache
 	 */
 	private $cache;
 
-	/**
-	 * The options handler.
-	 *
-	 * @var Options
-	 */
-	private $options;
 
 	/**
 	 * The default settings.
 	 *
 	 * @var Settings
-	 */
-	private $settings_template;
-
-	/**
-	 * The cached plugin settings.
-	 *
-	 * @var array
 	 */
 	private $settings;
 
@@ -152,18 +132,17 @@ class Core {
 	/**
 	 * Creates a new instance.
 	 *
-	 * @param string            $version           The plugin version string (e.g. "3.0.0-beta.2").
+	 * @since 4.2.0 Parameters $version and $options removed. Parameter $settings_template
+	 *              has been renamed to $settings.
+	 *
 	 * @param Cache             $cache             The object cache handler.
-	 * @param Options           $options           The options handler.
-	 * @param Settings          $settings_template The default settings template.
+	 * @param Settings          $settings          The settings handler.
 	 * @param Shortcodes_Filter $shortcodes_filter The shortcodes filter.
 	 * @param Media_Query       $media_query       The media query handler.
 	 */
-	public function __construct( $version, Cache $cache, Options $options, Settings $settings_template, Shortcodes_Filter $shortcodes_filter, Media_Query $media_query ) {
-		$this->version           = $version;
+	public function __construct( Cache $cache, Settings $settings, Shortcodes_Filter $shortcodes_filter, Media_Query $media_query ) {
 		$this->cache             = $cache;
-		$this->options           = $options;
-		$this->settings_template = $settings_template;
+		$this->settings          = $settings;
 		$this->media_query       = $media_query;
 		$this->shortcodes_filter = $shortcodes_filter;
 	}
@@ -206,7 +185,7 @@ class Core {
 	 * @return string
 	 */
 	public function get_version() {
-		return $this->version;
+		return $this->settings->get_version();
 	}
 
 	/**
@@ -215,11 +194,7 @@ class Core {
 	 * @return array
 	 */
 	public function get_settings() {
-		if ( empty( $this->settings ) ) {
-			$this->settings = $this->options->get( Options::OPTION, [] );
-		}
-
-		return $this->settings;
+		return $this->settings->get_all_settings();
 	}
 
 	/**

--- a/includes/media-credit/class-settings.php
+++ b/includes/media-credit/class-settings.php
@@ -168,7 +168,24 @@ class Settings {
 		$_defaults = $this->get_defaults();
 		$modified  = false;
 
+		// Maybe we need to use the old option name.
+		if ( false === $_settings ) {
+			$_settings = $this->options->get( 'media-credit', false, true );
+
+			if ( \is_array( $_settings ) ) {
+				// Let's move things to the new name.
+				$this->options->delete( 'media-credit', true );
+				$modified = true;
+			}
+		}
+
 		if ( \is_array( $_settings ) ) {
+			// Set correct installed version for really old installs (pre-1.0).
+			if ( ! isset( $_settings[ self::INSTALLED_VERSION ] ) ) {
+				$_settings[ self::INSTALLED_VERSION ] = '0.5.5-or-earlier';
+			}
+
+			// Ensure default values are set for all new settings.
 			foreach ( $_defaults as $name => $default_value ) {
 				if ( ! isset( $_settings[ $name ] ) ) {
 					$_settings[ $name ] = $default_value;
@@ -355,6 +372,7 @@ class Settings {
 
 			// Allow detection of new installations.
 			$_defaults[ self::INSTALLED_VERSION ] = '';
+			$_defaults[ self::INSTALL_DATE ]      = \gmdate( 'Y-m-d' );
 
 			$this->defaults = $_defaults;
 		}

--- a/includes/media-credit/components/class-settings-page.php
+++ b/includes/media-credit/components/class-settings-page.php
@@ -150,7 +150,7 @@ class Settings_Page implements \Media_Credit\Component {
 		\ob_start();
 
 		// The partial needs access to the plugin options and other internal data.
-		$options      = $this->options->get( Options::OPTION, [] );
+		$options      = $this->settings->get_all_settings();
 		$preview_data = $this->preview_data;
 
 		// Require partial.
@@ -200,7 +200,7 @@ class Settings_Page implements \Media_Credit\Component {
 		}
 
 		// Prepare valid options to preserve the version number.
-		$valid_options = $this->options->get( Options::OPTION, [] );
+		$valid_options = $this->settings->get_all_settings();
 
 		// Sanitize the actual input values.
 		foreach ( $input as $key => $value ) {

--- a/includes/media-credit/components/class-settings-page.php
+++ b/includes/media-credit/components/class-settings-page.php
@@ -150,8 +150,9 @@ class Settings_Page implements \Media_Credit\Component {
 		\ob_start();
 
 		// The partial needs access to the plugin options and other internal data.
-		$options      = $this->settings->get_all_settings();
+		$options      = $this->settings->get_all_settings(); // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- needed for partial
 		$preview_data = $this->preview_data;
+		// phpcs:enable
 
 		// Require partial.
 		require \MEDIA_CREDIT_PLUGIN_PATH . '/admin/partials/settings/preview.php';

--- a/includes/media-credit/components/class-setup.php
+++ b/includes/media-credit/components/class-setup.php
@@ -93,22 +93,35 @@ class Setup implements \Media_Credit\Component {
 		$current_settings = $this->settings->get_all_settings( true );
 
 		// Check if the plugin data needs to be updated.
-		$installed_version = $current_settings[ Settings::INSTALLED_VERSION ];
-		$version           = $this->settings->get_version();
-		$update_needed     = $version !== $installed_version;
-		$new_install       = empty( $installed_version );
+		$previous_version = $current_settings[ Settings::INSTALLED_VERSION ];
+		$version          = $this->settings->get_version();
+		$update_needed    = $version !== $previous_version;
 
-		// Upgrade plugin to 1.0.1.
-		if ( \version_compare( $installed_version, '1.0.1', '<' ) ) {
+		if ( $update_needed ) {
+			$this->maybe_update_postmeta_keys( $previous_version );
+		}
+
+		// Update installed version.
+		$this->settings->set( Settings::INSTALLED_VERSION, $version );
+	}
+
+	/**
+	 * Updates the postmeta keys if necessary.
+	 *
+	 * @since  4.2.0
+	 *
+	 * @param  string $previous_version The previously installed version.
+	 *
+	 * @return void
+	 */
+	protected function maybe_update_postmeta_keys( $previous_version ) {
+		if ( \version_compare( $previous_version, '1.0.1', '<' ) ) {
 			// Update all media-credit postmeta keys to _media_credit.
 			global $wpdb;
 
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->update( $wpdb->postmeta, [ 'meta_key' => Core::POSTMETA_KEY ], [ 'meta_key' => 'media-credit' ] );
 		}
-
-		// Update installed version.
-		$this->settings->set( Settings::INSTALLED_VERSION, $version );
 	}
 
 	/**

--- a/includes/media-credit/components/class-setup.php
+++ b/includes/media-credit/components/class-setup.php
@@ -97,14 +97,14 @@ class Setup implements \Media_Credit\Component {
 	public function update_check() {
 		// The default plugin options.
 		$default_options = [
-			'version'               => $this->version,
-			'install_date'          => \gmdate( 'Y-m-d' ),
-			'separator'             => Settings::DEFAULT_SEPARATOR,
-			'organization'          => \get_bloginfo( 'name', 'display' ),
-			'credit_at_end'         => false,
-			'no_default_credit'     => false,
-			'post_thumbnail_credit' => false,
-			'schema_org_markup'     => false,
+			Settings::INSTALLED_VERSION     => $this->version,
+			Settings::INSTALL_DATE          => \gmdate( 'Y-m-d' ),
+			Settings::SEPARATOR             => Settings::DEFAULT_SEPARATOR,
+			Settings::ORGANIZATION          => \get_bloginfo( 'name', 'display' ),
+			Settings::CREDIT_AT_END         => false,
+			Settings::NO_DEFAULT_CREDIT     => false,
+			Settings::FEATURED_IMAGE_CREDIT => false,
+			Settings::SCHEMA_ORG_MARKUP     => false,
 		];
 
 		// Retrieve options.
@@ -119,13 +119,13 @@ class Setup implements \Media_Credit\Component {
 		if ( empty( $installed_options ) ) {
 			// The plugin was installed for the frist time.
 			$installed_options = $default_options;
-		} elseif ( ! isset( $installed_options['version'] ) ) {
+		} elseif ( ! isset( $installed_options[ Settings::INSTALLED_VERSION ] ) ) {
 			// Upgrade plugin to 1.0 (0.5.5 didn't have a version number).
-			$installed_options['install_date'] = $default_options['install_date'];
+			$installed_options[ Settings::INSTALL_DATE ] = $default_options[ Settings::INSTALL_DATE ];
 		}
 
 		// Upgrade plugin to 1.0.1.
-		if ( \version_compare( $installed_options['version'], '1.0.1', '<' ) ) {
+		if ( \version_compare( $installed_options[ Settings::INSTALLED_VERSION ], '1.0.1', '<' ) ) {
 			// Update all media-credit postmeta keys to _media_credit.
 			global $wpdb;
 
@@ -134,22 +134,22 @@ class Setup implements \Media_Credit\Component {
 		}
 
 		// Upgrade plugin to 2.2.0.
-		if ( \version_compare( $installed_options['version'], '2.2.0', '<' ) ) {
-			$installed_options['no_default_credit'] = $default_options['no_default_credit'];
+		if ( \version_compare( $installed_options[ Settings::INSTALLED_VERSION ], '2.2.0', '<' ) ) {
+			$installed_options[ Settings::NO_DEFAULT_CREDIT ] = $default_options[ Settings::NO_DEFAULT_CREDIT ];
 		}
 
 		// Upgrade plugin to 3.0.0.
-		if ( \version_compare( $installed_options['version'], '3.0.0', '<' ) ) {
-			$installed_options['post_thumbnail_credit'] = $default_options['post_thumbnail_credit'];
+		if ( \version_compare( $installed_options[ Settings::INSTALLED_VERSION ], '3.0.0', '<' ) ) {
+			$installed_options[ Settings::FEATURED_IMAGE_CREDIT ] = $default_options[ Settings::FEATURED_IMAGE_CREDIT ];
 		}
 
 		// Upgrade plugin to 3.1.0.
-		if ( \version_compare( $installed_options['version'], '3.1.0', '<' ) ) {
-			$installed_options['schema_org_markup'] = $default_options['schema_org_markup'];
+		if ( \version_compare( $installed_options[ Settings::INSTALLED_VERSION ], '3.1.0', '<' ) ) {
+			$installed_options[ Settings::SCHEMA_ORG_MARKUP ] = $default_options[ Settings::SCHEMA_ORG_MARKUP ];
 		}
 
 		// Update installed version.
-		$installed_options['version'] = $this->version;
+		$installed_options[ Settings::INSTALLED_VERSION ] = $this->version;
 
 		// Store upgraded options.
 		if ( $original_options !== $installed_options ) {

--- a/includes/media-credit/components/class-shortcodes.php
+++ b/includes/media-credit/components/class-shortcodes.php
@@ -288,8 +288,9 @@ class Shortcodes implements \Media_Credit\Component {
 		$content = \do_shortcode( $content );
 
 		// Additional required template variables.
-		$inline_media_credit = [ $this, 'inline_media_credit' ];
+		$inline_media_credit = [ $this, 'inline_media_credit' ]; // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- needed for partial
 		$schema_org          = ! empty( $this->settings['schema_org_markup'] );
+		// phpcs:enable
 
 		// Start buffering.
 		\ob_start();

--- a/includes/media-credit/components/class-shortcodes.php
+++ b/includes/media-credit/components/class-shortcodes.php
@@ -28,7 +28,6 @@
 namespace Media_Credit\Components;
 
 use Media_Credit\Core;
-use Media_Credit\Data_Storage\Options;
 
 /**
  * The component providing the `[media-credit]` shortcode and patching `[caption]`

--- a/includes/media-credit/components/class-uninstallation.php
+++ b/includes/media-credit/components/class-uninstallation.php
@@ -28,10 +28,6 @@ namespace Media_Credit\Components;
 
 use Media_Credit\Data_Storage\Options;
 
-use Mundschenk\Data_Storage\Network_Options;
-use Mundschenk\Data_Storage\Site_Transients;
-use Mundschenk\Data_Storage\Transients;
-
 /**
  * Handles plugin uninstallation.
  *

--- a/includes/media-credit/tools/class-author-query.php
+++ b/includes/media-credit/tools/class-author-query.php
@@ -26,7 +26,6 @@
 
 namespace Media_Credit\Tools;
 
-use Media_Credit\Core;
 use Media_Credit\Data_Storage\Cache;
 
 /**

--- a/media-credit.php
+++ b/media-credit.php
@@ -38,6 +38,10 @@
 
 namespace Media_Credit;
 
+use Media_Credit_Factory;
+use Media_Credit\Controller;
+use Media_Credit\Requirements;
+
 // Don't do anything if called directly.
 if ( ! \defined( 'ABSPATH' ) || ! defined( 'WPINC' ) ) {
 	die();
@@ -74,7 +78,7 @@ function media_credit_run() {
 		 *
 		 * @var Controller
 		 */
-		$plugin = \Media_Credit_Factory::get()->create( Controller::class );
+		$plugin = Media_Credit_Factory::get()->create( Controller::class );
 		$plugin->run();
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -49,4 +49,24 @@
 
 	<!-- Include sniffs for PHP cross-version compatibility. -->
 	<rule ref="PHPCompatibilityWP" />
+
+
+		<!-- Check for undefined variables, except in partials. -->
+		<rule ref="VariableAnalysis">
+			<properties>
+				<property name="allowUnusedFunctionParameters" value="1" />
+			</properties>
+			<exclude-pattern>*/partials/*\.php</exclude-pattern>
+		</rule>
+
+		<!-- Check for unused symbols (or imports) -->
+		<rule ref="ImportDetection"/>
+		<rule ref="ImportDetection.Imports.RequireImports">
+			<properties>
+				<property name="ignoreUnimportedSymbols" value="/^Brain\\Monkey\\(Actions|Filters|Functions)$/"/>
+				<property name="ignoreGlobalsWhenInGlobalScope" value="true"/>
+				<property name="ignoreWordPressSymbols" value="true"/>
+			</properties>
+		</rule>
+
 </ruleset>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,13 +2,13 @@
 <phpunit
 	bootstrap="tests/bootstrap.php"
 	beStrictAboutTestsThatDoNotTestAnything="true"
-	beStrictAboutCoversAnnotation="true"
+	beStrictAboutCoversAnnotation="false"
 	stopOnRisky="true"
 	verbose="true"
 >
 	<testsuites>
 	    <testsuite name="MediaCredit">
-			<directory suffix="-test.php">tests</directory>
+			<directory suffix="_Test.php">tests</directory>
 	    </testsuite>
 	</testsuites>
 	<filter>

--- a/tests/Media_Credit/Components/Setup_Test.php
+++ b/tests/Media_Credit/Components/Setup_Test.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * This file is part of Media Credit.
+ *
+ * Copyright 2021 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/media-credit/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Media_Credit\Tests\Media_Credit\Components;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Media_Credit\Components\Setup;
+
+use Media_Credit\Core;
+use Media_Credit\Settings;
+
+/**
+ * Media_Credit\Components\Setup unit test.
+ *
+ * @coversDefaultClass \Media_Credit\Components\Setup
+ * @usesDefaultClass \Media_Credit\Components\Setup
+ *
+ * @uses ::__construct
+ */
+class Setup_Test extends \Media_Credit\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var Settings
+	 */
+	private $sut;
+
+	/**
+	 * Required helper object.
+	 *
+	 * @var Core
+	 */
+	private $core;
+
+	/**
+	 * Required helper object.
+	 *
+	 * @var Settings
+	 */
+	private $settings;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		Functions\when( '__' )->returnArg();
+
+		$this->core     = m::mock( Core::class );
+		$this->settings = m::mock( Settings::class );
+
+		$this->sut = m::mock( Setup::class, [ $this->core, $this->settings ] )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$core     = m::mock( Core::class );
+		$settings = m::mock( Settings::class );
+
+		$sut = m::mock( Setup::class )->makePartial();
+		$sut->__construct( $core, $settings );
+
+		$this->assert_attribute_same( $core, 'core', $sut );
+		$this->assert_attribute_same( $settings, 'settings', $sut );
+	}
+
+	/**
+	 * Tests ::run.
+	 *
+	 * @covers ::run
+	 */
+	public function test_run() {
+		Functions\expect( 'register_deactivation_hook' )->once()->with( \MEDIA_CREDIT_PLUGIN_FILE, [ $this->sut, 'deactivate' ] );
+
+		Actions\expectAdded( 'plugins_loaded' )->once()->with( [ $this->sut, 'update_check' ] );
+		Actions\expectAdded( 'init' )->once()->with( [ $this->sut, 'register_meta_fields' ] );
+
+		$this->assertNull( $this->sut->run() );
+	}
+
+	/**
+	 * Tests ::update_check.
+	 *
+	 * @covers ::update_check
+	 */
+	public function test_update_check() {
+		$version  = '6.6.6';
+		$settings = [
+			'foo'                       => 'bar',
+			Settings::INSTALLED_VERSION => '1.0.1',
+		];
+
+		$this->settings->shouldReceive( 'get_all_settings' )->once()->with( true )->andReturn( $settings );
+		$this->settings->shouldReceive( 'get_version' )->once()->andReturn( $version );
+		$this->settings->shouldReceive( 'set' )->once()->with( Settings::INSTALLED_VERSION, $version );
+
+		$this->assertNull( $this->sut->update_check() );
+	}
+
+	/**
+	 * Tests ::deactivate.
+	 *
+	 * @covers ::deactivate
+	 */
+	public function test_deactivate() {
+		$network_wide = true;
+
+		$this->assertNull( $this->sut->deactivate( $network_wide ) );
+	}
+
+	/**
+	 * Tests ::register_meta_fields.
+	 *
+	 * @covers ::register_meta_fields
+	 */
+	public function test_register_meta_fields() {
+		Functions\expect( 'register_meta' )->once()->with( 'post', Core::POSTMETA_KEY, m::type( 'array' ) );
+		Functions\expect( 'register_meta' )->once()->with( 'post', Core::URL_POSTMETA_KEY, m::type( 'array' ) );
+		Functions\expect( 'register_meta' )->once()->with( 'post', Core::DATA_POSTMETA_KEY, m::type( 'array' ) );
+
+		$this->assertNull( $this->sut->register_meta_fields() );
+	}
+}

--- a/tests/Media_Credit/Settings_Test.php
+++ b/tests/Media_Credit/Settings_Test.php
@@ -1,0 +1,456 @@
+<?php
+/**
+ * This file is part of Media Credit.
+ *
+ * Copyright 2021 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/media-credit/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Media_Credit\Tests;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Media_Credit\Settings;
+
+use Media_Credit\Data_Storage\Options;
+
+/**
+ * Media_Credit\Settings unit test.
+ *
+ * @coversDefaultClass \Media_Credit\Settings
+ * @usesDefaultClass \Media_Credit\Settings
+ *
+ * @uses ::__construct
+ */
+class Settings_Test extends \Media_Credit\Tests\TestCase {
+
+	const VERSION = '1.0.0';
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var Settings
+	 */
+	private $sut;
+
+	/**
+	 * Required helper object.
+	 *
+	 * @var Options
+	 */
+	private $options;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		Functions\when( '__' )->returnArg();
+
+		$this->options = m::mock( Options::class );
+
+		$this->sut = m::mock( Settings::class, [ self::VERSION, $this->options ] )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Test ::__construct.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @uses ::get_version
+	 */
+	public function test_constructor() {
+		$version = '6.6.6';
+		$options = m::mock( Options::class );
+
+		$sut = m::mock( Settings::class )->makePartial();
+		$sut->__construct( $version, $options );
+
+		$this->assert_attribute_same( $version, 'version', $sut );
+		$this->assert_attribute_same( $options, 'options', $sut );
+	}
+
+	/**
+	 * Tests ::get_version.
+	 *
+	 * @covers ::get_version
+	 */
+	public function test_get_version() {
+		$this->assertSame( self::VERSION, $this->sut->get_version() );
+	}
+
+	/**
+	 * Tests ::get_all_settings.
+	 *
+	 * @covers ::get_all_settings
+	 */
+	public function test_get_all_settings() {
+		$settings = [
+			'foo'                       => 'bar',
+			Settings::INSTALLED_VERSION => self::VERSION,
+		];
+
+		$this->sut->shouldReceive( 'load_settings' )->once()->andReturn( $settings );
+
+		$this->assertSame( $settings, $this->sut->get_all_settings() );
+	}
+
+	/**
+	 * Tests ::get_all_settings.
+	 *
+	 * @covers ::get_all_settings
+	 */
+	public function test_get_all_settings_repeated() {
+		$original = [
+			'foo'                       => 'bar',
+			Settings::INSTALLED_VERSION => self::VERSION,
+		];
+
+		// Prepare state - settings have alreaddy been loaded.
+		$this->set_value( $this->sut, 'settings', $original );
+
+		$this->sut->shouldReceive( 'load_settings' )->never();
+
+		$this->assertSame( $original, $this->sut->get_all_settings() );
+	}
+
+	/**
+	 * Tests ::get_all_settings.
+	 *
+	 * @covers ::get_all_settings
+	 */
+	public function test_get_all_settings_forced() {
+		$original = [
+			'foo'                       => 'bar',
+			Settings::INSTALLED_VERSION => self::VERSION,
+		];
+		$settings = [
+			'foo'                       => 'barfoo',
+			Settings::INSTALLED_VERSION => self::VERSION,
+		];
+
+		// Prepare state - settings have alreaddy been loaded.
+		$this->set_value( $this->sut, 'settings', $original );
+
+		$this->sut->shouldReceive( 'load_settings' )->once()->andReturn( $settings );
+
+		$this->assertSame( $settings, $this->sut->get_all_settings( true ) );
+	}
+
+	/**
+	 * Tests ::get_all_settings.
+	 *
+	 * @covers ::get_all_settings
+	 */
+	public function test_get_all_settings_no_version() {
+		$original = [
+			'foo' => 'bar',
+		];
+		$settings = [
+			'foo'                       => 'barfoo',
+			Settings::INSTALLED_VERSION => self::VERSION,
+		];
+
+		// Prepare state - settings have alreaddy been loaded.
+		$this->set_value( $this->sut, 'settings', $original );
+
+		$this->sut->shouldReceive( 'load_settings' )->once()->andReturn( $settings );
+
+		$this->assertSame( $settings, $this->sut->get_all_settings() );
+	}
+
+	/**
+	 * Tests ::get_all_settings.
+	 *
+	 * @covers ::get_all_settings
+	 */
+	public function test_get_all_settings_version_mismatch() {
+		$original = [
+			'foo'                       => 'bar',
+			Settings::INSTALLED_VERSION => '1.2.3',
+		];
+		$settings = [
+			'foo'                       => 'barfoo',
+			Settings::INSTALLED_VERSION => self::VERSION,
+		];
+
+		// Prepare state - settings have alreaddy been loaded.
+		$this->set_value( $this->sut, 'settings', $original );
+
+		$this->sut->shouldReceive( 'load_settings' )->once()->andReturn( $settings );
+
+		$this->assertSame( $settings, $this->sut->get_all_settings() );
+	}
+
+	/**
+	 * Tests ::load_settings.
+	 *
+	 * @covers ::load_settings
+	 */
+	public function test_load_settings() {
+		$setting1 = 'foo';
+		$setting2 = 'baz';
+		$settings = [
+			$setting1                   => 'barfoo',
+			Settings::INSTALLED_VERSION => '1.2.3',
+		];
+		$defaults = [
+			$setting1 => 'bar',
+			$setting2 => 'foobar',
+		];
+
+		$this->options->shouldReceive( 'get' )
+			->once()
+			->with( Options::OPTION )
+			->andReturn( $settings );
+
+		$this->sut->shouldReceive( 'get_defaults' )
+			->once()
+			->andReturn( $defaults );
+
+		$this->options->shouldReceive( 'set' )
+			->once()
+			->with( Options::OPTION, m::type( 'array' ) );
+
+		$result = $this->sut->load_settings();
+
+		$this->assert_is_array( $result );
+		$this->assertArrayHasKey( $setting1, $result );
+		$this->assertSame( 'barfoo', $result[ $setting1 ] );
+		$this->assertArrayHasKey( $setting2, $result );
+		$this->assertSame( 'foobar', $result[ $setting2 ] );
+		$this->assertArrayHasKey( Settings::INSTALLED_VERSION, $result );
+	}
+
+	/**
+	 * Tests ::load_settings.
+	 *
+	 * @covers ::load_settings
+	 */
+	public function test_load_settings_invalid_result() {
+		$defaults = [
+			'foo' => 'bar',
+			'baz' => 'foobar',
+		];
+
+		$this->options->shouldReceive( 'get' )
+			->once()
+			->with( Options::OPTION )
+			->andReturn( false );
+
+		$this->sut->shouldReceive( 'get_defaults' )
+			->once()
+			->andReturn( $defaults );
+
+		$this->options->shouldReceive( 'set' )
+			->once()
+			->with( Options::OPTION, m::type( 'array' ) );
+
+		$this->assertSame( $defaults, $this->sut->load_settings() );
+	}
+
+	/**
+	 * Tests ::load_settings.
+	 *
+	 * @covers ::load_settings
+	 */
+	public function test_load_settings_everything_in_order() {
+		$settings = [
+			'foo' => 'barfoo',
+			'baz' => 'foo',
+		];
+		$defaults = [
+			'foo' => 'bar',
+			'baz' => 'foobar',
+		];
+
+		$this->options->shouldReceive( 'get' )
+			->once()
+			->with( Options::OPTION )
+			->andReturn( $settings );
+
+		$this->sut->shouldReceive( 'get_defaults' )
+			->once()
+			->andReturn( $defaults );
+
+		$this->options->shouldReceive( 'set' )->never();
+
+		$this->assertSame( $settings, $this->sut->load_settings() );
+	}
+
+	/**
+	 * Tests ::get.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$setting_key   = 'foo';
+		$setting_value = 'bar';
+		$settings      = [
+			$setting_key => $setting_value,
+			'something'  => 'else',
+		];
+
+		$this->sut->shouldReceive( 'get_all_settings' )->once()->andReturn( $settings );
+
+		$this->assertSame( $setting_value, $this->sut->get( $setting_key ) );
+	}
+
+	/**
+	 * Tests ::get.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get_invalid_setting() {
+		$setting_key   = 'foo';
+		$setting_value = 'bar';
+		$settings      = [
+			$setting_key => $setting_value,
+			'something'  => 'else',
+		];
+
+		$this->sut->shouldReceive( 'get_all_settings' )->once()->andReturn( $settings );
+		$this->expect_exception( \UnexpectedValueException::class );
+
+		$this->assertNull( $this->sut->get( 'invalid setting' ) );
+	}
+
+	/**
+	 * Tests ::set.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set() {
+		$setting_key   = 'my_key';
+		$setting_value = 'bar';
+
+		$orig_settings = [
+			'a_setting'  => 666,
+			$setting_key => 'some other value',
+			'something'  => 'else',
+		];
+
+		$new_settings                 = $orig_settings;
+		$new_settings[ $setting_key ] = $setting_value;
+
+		$this->sut->shouldReceive( 'get_all_settings' )->once()->andReturn( $orig_settings );
+		$this->options->shouldReceive( 'set' )->once()->with( Options::OPTION, $new_settings )->andReturn( true );
+
+		$this->assertTrue( $this->sut->set( $setting_key, $setting_value ) );
+		$this->assert_attribute_same( $new_settings, 'settings', $this->sut );
+	}
+
+	/**
+	 * Tests ::set.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set_db_error() {
+		$setting_key   = 'my_key';
+		$setting_value = 'bar';
+		$orig_settings = [
+			'a_setting'  => 666,
+			$setting_key => 'some other value',
+			'something'  => 'else',
+		];
+
+		$new_settings                 = $orig_settings;
+		$new_settings[ $setting_key ] = $setting_value;
+
+		$cached_settings = $this->get_value( $this->sut, 'settings' );
+
+		$this->sut->shouldReceive( 'get_all_settings' )->once()->andReturn( $orig_settings );
+		$this->options->shouldReceive( 'set' )->once()->with( Options::OPTION, $new_settings )->andReturn( false );
+
+		$this->assertFalse( $this->sut->set( $setting_key, $setting_value ) );
+		$this->assert_attribute_same( $cached_settings, 'settings', $this->sut );
+	}
+
+	/**
+	 * Tests ::set.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set_invalid_setting() {
+		$setting_key   = 'invalid_key';
+		$setting_value = 'bar';
+		$orig_settings = [
+			'a_setting' => 666,
+			'my_key'    => 'some other value',
+			'something' => 'else',
+		];
+
+		$cached_settings = $this->get_value( $this->sut, 'settings' );
+
+		$this->sut->shouldReceive( 'get_all_settings' )->once()->andReturn( $orig_settings );
+
+		$this->expect_exception( \UnexpectedValueException::class );
+
+		$this->options->shouldReceive( 'set' )->never();
+
+		$this->assertNull( $this->sut->set( $setting_key, $setting_value ) );
+		$this->assert_attribute_same( $cached_settings, 'settings', $this->sut );
+	}
+
+	/**
+	 * Tests ::get_fields.
+	 *
+	 * @covers ::get_fields
+	 */
+	public function test_get_fields() {
+		$site_name = 'My Cool Site';
+
+		Functions\expect( 'get_bloginfo' )->once()->with( 'name', 'display' )->andReturn( $site_name );
+
+		$result = $this->sut->get_fields();
+
+		$this->assert_is_array( $result );
+		$this->assertContainsOnly( 'string', \array_keys( $result ) );
+		$this->assertContainsOnly( 'array', $result );
+	}
+
+	/**
+	 * Tests ::get_defaults.
+	 *
+	 * @covers ::get_defaults
+	 *
+	 * @uses ::get_fields
+	 */
+	public function test_get_defaults() {
+		$site_name = 'My Cool Site';
+
+		Functions\expect( 'get_bloginfo' )->once()->with( 'name', 'display' )->andReturn( $site_name );
+
+		$result = $this->sut->get_defaults();
+
+		$this->assert_is_array( $result );
+		$this->assertNotContainsOnly( 'array', $result );
+		$this->assertSame( '', $result[ Settings::INSTALLED_VERSION ] );
+	}
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,7 +20,7 @@
  *
  *  ***
  *
- * @package mundschenk-at/avatar-privacy/tests
+ * @package mundschenk-at/media-credit/tests
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -26,6 +26,7 @@
 
 namespace Media_Credit;
 
+use Media_Credit\Requirements;
 use Media_Credit\Components\Uninstallation;
 
 // Don't do anything if called directly.


### PR DESCRIPTION
- Refactors `Media_Credit\Settings` to fully encapsulate plugin settings.
- Adds unit tests.
- Cleans up imports (`use` statements).