### PR TITLE
Additional code cleanup

### DIFF
--- a/includes/class-media-credit-factory.php
+++ b/includes/class-media-credit-factory.php
@@ -104,7 +104,7 @@ class Media_Credit_Factory extends Dice {
 		];
 
 		// Define rules.
-		$rules = [
+		return [
 			// Core API.
 			Core::class                         => self::SHARED,
 			Settings::class                     => [
@@ -131,8 +131,6 @@ class Media_Credit_Factory extends Dice {
 			Component::class                    => self::SHARED,
 			Components\Classic_Editor::class    => $version_rule,
 		];
-
-		return $rules;
 	}
 
 	/**

--- a/includes/class-media-credit-factory.php
+++ b/includes/class-media-credit-factory.php
@@ -32,6 +32,7 @@ use Media_Credit\Component;
 use Media_Credit\Components;
 use Media_Credit\Tools;
 use Media_Credit\Settings;
+use Media_Credit\Exceptions\Factory_Exception;
 
 use Mundschenk\Data_Storage;
 
@@ -64,11 +65,11 @@ class Media_Credit_Factory extends Dice {
 	 * Retrieves a factory set up for creating Media_Credit instances.
 	 *
 	 * @since 4.1.0 Parameter $full_plugin_path replaced with MEDIA_CREDIT_PLUGIN_PATH constant.
-	 * @since 4.2.0 Now throws a RuntimeException in case of error.
+	 * @since 4.2.0 Now throws a Factory_Exception in case of error.
 	 *
 	 * @return Media_Credit_Factory
 	 *
-	 * @throws RuntimeException An exception is thrown if the factory cannot be created.
+	 * @throws Factory_Exception An exception is thrown if the factory cannot be created.
 	 */
 	public static function get() {
 		if ( ! isset( self::$factory ) ) {
@@ -80,7 +81,7 @@ class Media_Credit_Factory extends Dice {
 			if ( $factory instanceof Media_Credit_Factory ) {
 				self::$factory = $factory;
 			} else {
-				throw new RuntimeException( 'Could not create object factory.' ); // @codeCoverageIgnore
+				throw new Factory_Exception( 'Could not create object factory.' ); // @codeCoverageIgnore
 			}
 		}
 

--- a/includes/media-credit-template.php
+++ b/includes/media-credit-template.php
@@ -124,12 +124,11 @@ if ( ! function_exists( 'get_media_credit_html' ) ) {
 	 * @since  4.0.0 The function has been deprecated in favor of Media_Credit::get_html.
 	 * @since  4.2.0 The parameter $post needs needs to be specified.
 	 *
-	 * @param  int|\WP_Post $post       An attachment ID or the corresponding \WP_Post object.
-	 * @param  bool         $deprecated Optional. Deprecated argument. Default true.
+	 * @param  int|\WP_Post $post An attachment ID or the corresponding \WP_Post object.
 	 *
 	 * @return string
 	 */
-	function get_media_credit_html( $post = null, $deprecated = true ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- legacy API.
+	function get_media_credit_html( $post = null ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- legacy API.
 		_deprecated_function( __FUNCTION__, '4.0.0', 'Media_Credit::get_html' );
 
 		if ( empty( $post ) ) {

--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -277,6 +277,9 @@ class Core {
 				case self::DATA_POSTMETA_KEY:
 					$meta_value = \is_array( $meta_value ) ? $meta_value : [];
 					break;
+
+				default:
+					// Ignore unknown key.
 			}
 		}
 

--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -712,4 +712,30 @@ class Core {
 	public function print_partial( $partial, array $args = [] ) {
 		$this->template->print_partial( $partial, $args );
 	}
+
+	/**
+	 * Adds schema.org markup to the <figure>/<figcaption> markup if it does not
+	 * already contain `itemtype`/`itemprop` attributes.
+	 *
+	 * @internal
+	 *
+	 * @since  4.2.0
+	 *
+	 * @param  string $markup The caption markup.
+	 *
+	 * @return string
+	 */
+	public function maybe_add_schema_org_markup_to_figure( $markup ) {
+		// Inject schema.org markup for figure.
+		if ( ! \preg_match( '/<figure[^>]*\bitemscope\b/S', $markup ) ) {
+			$markup = \preg_replace( '/<figure\b/S', '<figure itemscope itemtype="http://schema.org/ImageObject"', $markup ) ?? $markup;
+		}
+
+		// Inject schema.org markup for figcaption.
+		if ( ! \preg_match( '/<figcaption[^>]*\bitemprop\s*=/S', $markup ) ) {
+			$markup = \preg_replace( '/<figcaption\b/S', '<figcaption itemprop="caption"', $markup ) ?? $markup;
+		}
+
+		return $markup;
+	}
 }

--- a/includes/media-credit/components/class-block-editor.php
+++ b/includes/media-credit/components/class-block-editor.php
@@ -92,18 +92,15 @@ class Block_Editor implements \Media_Credit\Component {
 
 		// Load the media credit for the attachment.
 		$credit = $this->core->get_media_credit_json( $attachment );
-		if ( empty( $credit['rendered'] ) ) {
-			// No credit to display, let's bail.
-			return $block_content;
-		}
+		if ( ! empty( $credit['rendered'] ) ) {
+			// Inject the (modified) caption markup.
+			$markup        = $this->core->wrap_media_credit_markup( $credit['rendered'], $include_schema_org );
+			$block_content = $this->inject_credit_into_caption( $block_content, $markup );
 
-		// Inject the (modified) caption markup.
-		$markup        = $this->core->wrap_media_credit_markup( $credit['rendered'], $include_schema_org );
-		$block_content = $this->inject_credit_into_caption( $block_content, $markup );
-
-		// Inject additional schema.org markup.
-		if ( $include_schema_org ) {
-			$block_content = $this->core->maybe_add_schema_org_markup_to_figure( $block_content );
+			// Inject additional schema.org markup.
+			if ( $include_schema_org ) {
+				$block_content = $this->core->maybe_add_schema_org_markup_to_figure( $block_content );
+			}
 		}
 
 		return $block_content;

--- a/includes/media-credit/components/class-block-editor.php
+++ b/includes/media-credit/components/class-block-editor.php
@@ -103,15 +103,7 @@ class Block_Editor implements \Media_Credit\Component {
 
 		// Inject additional schema.org markup.
 		if ( $include_schema_org ) {
-			// <figure> markup.
-			if ( ! \preg_match( '/<figure[^>]*\bitemscope\b/S', $block_content ) ) {
-				$block_content = \preg_replace( '/<figure\b/S', '<figure itemscope itemtype="http://schema.org/ImageObject"', $block_content ) ?? $block_content;
-			}
-
-			// <figcaption> markup.
-			if ( ! \preg_match( '/<figcaption[^>]*\bitemprop\s*=\b/S', $block_content ) ) {
-				$block_content = \preg_replace( '/<figcaption\b/S', '<figcaption itemprop="caption"', $block_content ) ?? $block_content;
-			}
+			$block_content = $this->core->maybe_add_schema_org_markup_to_figure( $block_content );
 		}
 
 		return $block_content;

--- a/includes/media-credit/components/class-frontend.php
+++ b/includes/media-credit/components/class-frontend.php
@@ -276,13 +276,12 @@ class Frontend implements \Media_Credit\Component {
 		}
 
 		$credit = $this->get_featured_image_credit( $post_id, $post_thumbnail_id );
-		if ( empty( $credit ) ) {
-			// Don't print an empty default credit.
-			return $html;
+		if ( ! empty( $credit ) ) {
+			// Add styled & wrapped credit markup.
+			$html .= $this->core->wrap_media_credit_markup( $credit, false, $this->get_featured_image_credit_style( $html ) );
 		}
 
-		// Return styled & wrapped credit markup.
-		return $html . $this->core->wrap_media_credit_markup( $credit, false, $this->get_featured_image_credit_style( $html ) );
+		return $html;
 	}
 
 	/**

--- a/includes/media-credit/components/class-rest-api.php
+++ b/includes/media-credit/components/class-rest-api.php
@@ -284,7 +284,7 @@ class REST_API implements \Media_Credit\Component {
 		$params = $request->get_params();
 
 		// Return the filtered post content in a response object.
-		$response = new \WP_REST_Response(
+		return new \WP_REST_Response(
 			$this->shortcodes_filter->update_changed_media_credits(
 				$params['content'],
 				$params['attachment_id'],
@@ -294,7 +294,5 @@ class REST_API implements \Media_Credit\Component {
 				$params['nofollow']
 			)
 		);
-
-		return $response;
 	}
 }

--- a/includes/media-credit/components/class-settings-page.php
+++ b/includes/media-credit/components/class-settings-page.php
@@ -203,14 +203,11 @@ class Settings_Page implements \Media_Credit\Component {
 
 		// Sanitize the actual input values.
 		foreach ( $input as $key => $value ) {
-			switch ( $key ) {
-				case Settings::SEPARATOR:
-					// We can't use sanitize_text_field because we want to keep enclosing whitespace.
-					$valid_options[ $key ] = \wp_kses( $value, [] );
-					break;
-
-				default:
-					$valid_options[ $key ] = \sanitize_text_field( $value );
+			if ( Settings::SEPARATOR === $key ) {
+				// We can't use sanitize_text_field because we want to keep enclosing whitespace.
+				$valid_options[ $key ] = \wp_kses( $value, [] );
+			} else {
+				$valid_options[ $key ] = \sanitize_text_field( $value );
 			}
 		}
 

--- a/includes/media-credit/components/class-shortcodes.php
+++ b/includes/media-credit/components/class-shortcodes.php
@@ -208,31 +208,7 @@ class Shortcodes implements \Media_Credit\Component {
 
 		// Optionally add schema.org markup.
 		if ( $schema_org ) {
-			$caption = $this->maybe_add_schema_org_markup_to_caption( $caption );
-		}
-
-		return $caption;
-	}
-
-	/**
-	 * Adds schema.org markup to the caption if it does not already contain
-	 * `itemtype`/`itemprop` attributes.
-	 *
-	 * @since  4.2.0
-	 *
-	 * @param  string $caption The caption markup.
-	 *
-	 * @return string
-	 */
-	protected function maybe_add_schema_org_markup_to_caption( $caption ) {
-		// Inject schema.org markup for figure.
-		if ( ! \preg_match( '/<figure[^>]*\bitemscope\b/S', $caption ) ) {
-			$caption = \preg_replace( '/<figure\b/S', '<figure itemscope itemtype="http://schema.org/ImageObject"', $caption ) ?? $caption;
-		}
-
-		// Inject schema.org markup for figcaption.
-		if ( ! \preg_match( '/<figcaption[^>]*\bitemprop\s*=/S', $caption ) ) {
-			$caption = \preg_replace( '/<figcaption\b/S', '<figcaption itemprop="caption"', $caption ) ?? $caption;
+			$caption = $this->core->maybe_add_schema_org_markup_to_figure( $caption );
 		}
 
 		return $caption;

--- a/includes/media-credit/exceptions/class-factory-exception.php
+++ b/includes/media-credit/exceptions/class-factory-exception.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of Media Credit.
+ *
+ * Copyright 2021 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/media-credit
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Media_Credit\Exceptions;
+
+/**
+ * An exception indicating a problem with the object factory.
+ *
+ * @since 4.2.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Factory_Exception extends \RuntimeException {
+}

--- a/tests/Media_Credit/Components/Block_Editor_Test.php
+++ b/tests/Media_Credit/Components/Block_Editor_Test.php
@@ -192,6 +192,7 @@ class Block_Editor_Test extends TestCase {
 		$this->core->shouldReceive( 'get_media_credit_json' )->once()->with( $attachment )->andReturn( $credit_json );
 		$this->core->shouldReceive( 'wrap_media_credit_markup' )->once()->with( $rendered_credit, $schema_org )->andReturn( $wrapped_credit );
 		$this->sut->shouldReceive( 'inject_credit_into_caption' )->once()->with( $block_content, $wrapped_credit )->andReturn( $injected_block_content );
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->once()->with( $injected_block_content )->andReturn( $result );
 
 		$this->assertSame( $result, $this->sut->add_media_credit_to_image_blocks( $block_content, $block ) );
 	}
@@ -230,6 +231,7 @@ class Block_Editor_Test extends TestCase {
 		$this->core->shouldReceive( 'get_media_credit_json' )->never();
 		$this->core->shouldReceive( 'wrap_media_credit_markup' )->never();
 		$this->sut->shouldReceive( 'inject_credit_into_caption' )->never();
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->never();
 
 		$this->assertSame( $result, $this->sut->add_media_credit_to_image_blocks( $block_content, $block ) );
 	}
@@ -268,6 +270,7 @@ class Block_Editor_Test extends TestCase {
 		$this->core->shouldReceive( 'get_media_credit_json' )->never();
 		$this->core->shouldReceive( 'wrap_media_credit_markup' )->never();
 		$this->sut->shouldReceive( 'inject_credit_into_caption' )->never();
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->never();
 
 		$this->assertSame( $result, $this->sut->add_media_credit_to_image_blocks( $block_content, $block ) );
 	}
@@ -303,6 +306,7 @@ class Block_Editor_Test extends TestCase {
 		$this->core->shouldReceive( 'get_media_credit_json' )->never();
 		$this->core->shouldReceive( 'wrap_media_credit_markup' )->never();
 		$this->sut->shouldReceive( 'inject_credit_into_caption' )->never();
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->never();
 
 		$this->assertSame( $result, $this->sut->add_media_credit_to_image_blocks( $block_content, $block ) );
 	}
@@ -341,6 +345,7 @@ class Block_Editor_Test extends TestCase {
 		$this->core->shouldReceive( 'get_media_credit_json' )->never();
 		$this->core->shouldReceive( 'wrap_media_credit_markup' )->never();
 		$this->sut->shouldReceive( 'inject_credit_into_caption' )->never();
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->never();
 
 		$this->assertSame( $result, $this->sut->add_media_credit_to_image_blocks( $block_content, $block ) );
 	}
@@ -383,6 +388,7 @@ class Block_Editor_Test extends TestCase {
 		$this->core->shouldReceive( 'get_media_credit_json' )->once()->with( $attachment )->andReturn( $credit_json );
 		$this->core->shouldReceive( 'wrap_media_credit_markup' )->never();
 		$this->sut->shouldReceive( 'inject_credit_into_caption' )->never();
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->never();
 
 		$this->assertSame( $result, $this->sut->add_media_credit_to_image_blocks( $block_content, $block ) );
 	}

--- a/tests/Media_Credit/Components/Shortcodes_Test.php
+++ b/tests/Media_Credit/Components/Shortcodes_Test.php
@@ -178,7 +178,7 @@ class Shortcodes_Test extends TestCase {
 		Filters\expectApplied( 'media_credit_shortcode_html5_caption' )->never();
 
 		Functions\expect( 'img_caption_shortcode' )->once()->with( $attr_with_caption, $captionless_content )->andReturn( $result );
-		$this->sut->shouldReceive( 'maybe_add_schema_org_markup_to_caption' )->never();
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->never();
 
 		$this->assertSame( $result, $this->sut->caption_shortcode( $attr, $content ) );
 	}
@@ -229,7 +229,7 @@ class Shortcodes_Test extends TestCase {
 		Filters\expectApplied( 'media_credit_shortcode_html5_caption' )->once()->with( "{$caption} {$credit}", $caption, $credit, $sanitized_mc_attr )->andReturn( $filtered_html5_caption );
 		Functions\expect( 'img_caption_shortcode' )->once()->with( $attr_with_caption, $captionless_content )->andReturn( $result );
 
-		$this->sut->shouldReceive( 'maybe_add_schema_org_markup_to_caption' )->never();
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->never();
 
 		$this->assertSame( $result, $this->sut->caption_shortcode( $attr, $content ) );
 	}
@@ -271,7 +271,7 @@ class Shortcodes_Test extends TestCase {
 
 		Functions\expect( 'img_caption_shortcode' )->once()->with( $attr_with_caption, $content_without_mediacredit )->andReturn( $result );
 
-		$this->sut->shouldReceive( 'maybe_add_schema_org_markup_to_caption' )->never();
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->never();
 
 		$this->assertSame( $result, $this->sut->caption_shortcode( $attr, $content ) );
 	}
@@ -323,7 +323,7 @@ class Shortcodes_Test extends TestCase {
 		Filters\expectApplied( 'media_credit_shortcode_html5_caption' )->once()->with( "{$caption} {$credit}", $caption, $credit, $sanitized_mc_attr )->andReturn( $filtered_html5_caption );
 		Functions\expect( 'img_caption_shortcode' )->once()->with( $attr_with_caption, $captionless_content )->andReturn( $caption_markup );
 
-		$this->sut->shouldReceive( 'maybe_add_schema_org_markup_to_caption' )->once()->with( $caption_markup )->andReturn( $result );
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->once()->with( $caption_markup )->andReturn( $result );
 
 		$this->assertSame( $result, $this->sut->caption_shortcode( $attr, $content ) );
 	}
@@ -363,7 +363,7 @@ class Shortcodes_Test extends TestCase {
 
 		Functions\expect( 'img_caption_shortcode' )->once()->with( $attr, $content )->andReturn( $caption_markup );
 
-		$this->sut->shouldReceive( 'maybe_add_schema_org_markup_to_caption' )->once()->with( $caption_markup )->andReturn( $result );
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->once()->with( $caption_markup )->andReturn( $result );
 
 		$this->assertSame( $result, $this->sut->caption_shortcode( $attr, $content ) );
 	}
@@ -401,7 +401,7 @@ class Shortcodes_Test extends TestCase {
 
 		Functions\expect( 'img_caption_shortcode' )->once()->with( $attr, $content )->andReturn( $caption_markup );
 
-		$this->sut->shouldReceive( 'maybe_add_schema_org_markup_to_caption' )->once()->with( $caption_markup )->andReturn( $result );
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->once()->with( $caption_markup )->andReturn( $result );
 
 		$this->assertSame( $result, $this->sut->caption_shortcode( $attr, $content ) );
 	}
@@ -441,60 +441,9 @@ class Shortcodes_Test extends TestCase {
 
 		Functions\expect( 'img_caption_shortcode' )->once()->with( $attr, $content )->andReturn( $caption_markup );
 
-		$this->sut->shouldReceive( 'maybe_add_schema_org_markup_to_caption' )->once()->with( $caption_markup )->andReturn( $result );
+		$this->core->shouldReceive( 'maybe_add_schema_org_markup_to_figure' )->once()->with( $caption_markup )->andReturn( $result );
 
 		$this->assertSame( $result, $this->sut->caption_shortcode( $attr, $content ) );
-	}
-
-	/**
-	 * Provides data for testing ::maybe_add_schema_org_markup_to_caption.
-	 *
-	 * @return array
-	 */
-	public function provide_maybe_add_schema_org_markup_to_caption_data() {
-		return [
-			// Noop.
-			[ '', '' ],
-			// <figure> only.
-			[
-				'<figure foo="bar">FOOBAR</figure>',
-				'<figure itemscope itemtype="http://schema.org/ImageObject" foo="bar">FOOBAR</figure>',
-			],
-			// <figure> with <figcaption>.
-			[
-				'<figure foo="bar">FOOBAR <figcaption class="some-class">Oh caption, my caption!</figcaption></figure>',
-				'<figure itemscope itemtype="http://schema.org/ImageObject" foo="bar">FOOBAR <figcaption itemprop="caption" class="some-class">Oh caption, my caption!</figcaption></figure>',
-			],
-			// <figure> with <figcaption>, pre-existing 'itemscope'.
-			[
-				'<figure foo="bar" itemscope itemtype="some://thing">FOOBAR <figcaption class="some-class">Oh caption, my caption!</figcaption></figure>',
-				'<figure foo="bar" itemscope itemtype="some://thing">FOOBAR <figcaption itemprop="caption" class="some-class">Oh caption, my caption!</figcaption></figure>',
-			],
-			// <figure> with <figcaption>, pre-existing 'itemprop' on <figcaption>.
-			[
-				'<figure foo="bar">FOOBAR <figcaption class="some-class" itemprop="foo">Oh caption, my caption!</figcaption></figure>',
-				'<figure itemscope itemtype="http://schema.org/ImageObject" foo="bar">FOOBAR <figcaption class="some-class" itemprop="foo">Oh caption, my caption!</figcaption></figure>',
-			],
-			// <figure> with <figcaption>, pre-existing 'itemscope' and 'itemprop' (on <figcaption>).
-			[
-				'<figure foo="bar"itemscope itemtype="some://thing">FOOBAR <figcaption class="some-class" itemprop="foo">Oh caption, my caption!</figcaption></figure>',
-				'<figure foo="bar"itemscope itemtype="some://thing">FOOBAR <figcaption class="some-class" itemprop="foo">Oh caption, my caption!</figcaption></figure>',
-			],
-		];
-	}
-
-	/**
-	 * Tests ::maybe_add_schema_org_markup_to_caption.
-	 *
-	 * @covers ::maybe_add_schema_org_markup_to_caption
-	 *
-	 * @dataProvider provide_maybe_add_schema_org_markup_to_caption_data
-	 *
-	 * @param string $caption The caption.
-	 * @param string $result  The expected result.
-	 */
-	public function test_maybe_add_schema_org_markup_to_caption( $caption, $result ) {
-		$this->assertSame( $result, $this->sut->maybe_add_schema_org_markup_to_caption( $caption ) );
 	}
 
 	/**

--- a/tests/Media_Credit/Core_Test.php
+++ b/tests/Media_Credit/Core_Test.php
@@ -1323,4 +1323,55 @@ class Core_Test extends TestCase {
 
 		$this->assertNull( $this->sut->print_partial( $partial, $args ) );
 	}
+
+	/**
+	 * Provides data for testing ::maybe_add_schema_org_markup_to_figure.
+	 *
+	 * @return array
+	 */
+	public function provide_maybe_add_schema_org_markup_to_figure_data() {
+		return [
+			// Noop.
+			[ '', '' ],
+			// <figure> only.
+			[
+				'<figure foo="bar">FOOBAR</figure>',
+				'<figure itemscope itemtype="http://schema.org/ImageObject" foo="bar">FOOBAR</figure>',
+			],
+			// <figure> with <figcaption>.
+			[
+				'<figure foo="bar">FOOBAR <figcaption class="some-class">Oh caption, my caption!</figcaption></figure>',
+				'<figure itemscope itemtype="http://schema.org/ImageObject" foo="bar">FOOBAR <figcaption itemprop="caption" class="some-class">Oh caption, my caption!</figcaption></figure>',
+			],
+			// <figure> with <figcaption>, pre-existing 'itemscope'.
+			[
+				'<figure foo="bar" itemscope itemtype="some://thing">FOOBAR <figcaption class="some-class">Oh caption, my caption!</figcaption></figure>',
+				'<figure foo="bar" itemscope itemtype="some://thing">FOOBAR <figcaption itemprop="caption" class="some-class">Oh caption, my caption!</figcaption></figure>',
+			],
+			// <figure> with <figcaption>, pre-existing 'itemprop' on <figcaption>.
+			[
+				'<figure foo="bar">FOOBAR <figcaption class="some-class" itemprop="foo">Oh caption, my caption!</figcaption></figure>',
+				'<figure itemscope itemtype="http://schema.org/ImageObject" foo="bar">FOOBAR <figcaption class="some-class" itemprop="foo">Oh caption, my caption!</figcaption></figure>',
+			],
+			// <figure> with <figcaption>, pre-existing 'itemscope' and 'itemprop' (on <figcaption>).
+			[
+				'<figure foo="bar"itemscope itemtype="some://thing">FOOBAR <figcaption class="some-class" itemprop="foo">Oh caption, my caption!</figcaption></figure>',
+				'<figure foo="bar"itemscope itemtype="some://thing">FOOBAR <figcaption class="some-class" itemprop="foo">Oh caption, my caption!</figcaption></figure>',
+			],
+		];
+	}
+
+	/**
+	 * Tests ::maybe_add_schema_org_markup_to_figure.
+	 *
+	 * @covers ::maybe_add_schema_org_markup_to_figure
+	 *
+	 * @dataProvider provide_maybe_add_schema_org_markup_to_figure_data
+	 *
+	 * @param string $caption The caption.
+	 * @param string $result  The expected result.
+	 */
+	public function test_maybe_add_schema_org_markup_to_figure( $caption, $result ) {
+		$this->assertSame( $result, $this->sut->maybe_add_schema_org_markup_to_figure( $caption ) );
+	}
 }


### PR DESCRIPTION
- Extracts common `schema.org` injection code to ´Media_Credit\Core::maybe_add_schema_org_markup_to_figure`.
- Removes unnecessary temporary variable assignments before `return`.
- Simplifies function control flow.
- Removes unused deprecated function parameters.