### PR TITLE
Add filter hook media_credit_disable_author_urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 *   _Feature_: A shorter label for credits displayed at the end of a post can be
     enabled via the new filter hook `media_credit_at_end_use_short_label` (`Images:`
     instead of `Images courtesy of`).
+*   _Feature_: The automatic linking of user credits to the WordPress author page
+    can be disabled with the new filter hook `media_credit_disable_author_urls`.
 *   _Bugfix_: The credit overlay cannot be selected any more by accident in the
     classic editor.
 *   _Bugfix_: Several visual glitches in classic editor have been fixed and parsing

--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -364,7 +364,7 @@ class Core {
 			}
 
 			$name   = \get_the_author_meta( 'display_name', $user_id );
-			$url    = $url ?: \get_author_posts_url( $user_id ); // phpcs:ignore WordPress.PHP.DisallowShortTernary
+			$url    = $this->get_author_credit_url( $user_id, $url );
 			$suffix = $this->get_organization_suffix();
 		}
 
@@ -377,6 +377,35 @@ class Core {
 
 		// The suffix should not contain any markup (the credit might).
 		return $credit . \esc_html( $suffix );
+	}
+
+	/**
+	 * Retrieves the URL to use for the author credit.
+	 *
+	 * @since  4.2.0
+	 *
+	 * @param  int    $user_id    The author's user ID.
+	 * @param  string $custom_url A custom URL for the credit (maybe empty).
+	 *
+	 * @return string
+	 */
+	protected function get_author_credit_url( $user_id, $custom_url ) {
+		/**
+		 * Filters whether to disable automatic linking to the author page (for
+		 * default credits).
+		 *
+		 * @since  4.2.0
+		 *
+		 * @param  bool $disable Whether to disable linking to the author page.
+		 *                       Default false.
+		 */
+		$disable_author_urls = \apply_filters( 'media_credit_disable_author_urls', false );
+
+		if ( empty( $custom_url ) && ! $disable_author_urls ) {
+			return \get_author_posts_url( $user_id );
+		}
+
+		return $custom_url;
 	}
 
 	/**

--- a/includes/media-credit/components/class-shortcodes.php
+++ b/includes/media-credit/components/class-shortcodes.php
@@ -345,29 +345,16 @@ class Shortcodes implements \Media_Credit\Component {
 	 * @return string
 	 */
 	protected function inline_media_credit( array $attr, $include_schema_org = false ) {
+		// Prepare arguments for compatibility with old shortcode behavior (`id` trumps `naem`).
+		$user_id  = $attr['id'];
+		$freeform = $user_id > 0 ? '' : $attr['name'];
+		$url      = $attr['link'];
+		$flags    = [
+			'nofollow' => $attr['nofollow'],
+		];
 
-		// The default credit and link.
-		$credit        = $attr['name'];
-		$credit_suffix = '';
-		$url           = $attr['link'];
-
-		// If present, use the user ID.
-		if ( $attr['id'] > 0 ) {
-			$credit        = \get_the_author_meta( 'display_name', $attr['id'] );
-			$credit_suffix = $this->core->get_organization_suffix();
-			$url           = $url ?: \get_author_posts_url( $attr['id'] ); // phpcs:ignore WordPress.PHP.DisallowShortTernary
-		}
-
-		// The credit should not contain any HTML.
-		$credit = \esc_html( $credit );
-
-		// Wrap credit in link if URL is set.
-		if ( $url ) {
-			$credit = '<a href="' . \esc_url( $url ) . '"' . ( ! empty( $attr['nofollow'] ) ? ' rel="nofollow"' : '' ) . '>' . $credit . '</a>';
-		}
-
-		// Add suffix (no HTML there, too).
-		$credit .= \esc_html( $credit_suffix );
+		// Render shortcode.
+		$credit = $this->core->render_media_credit_html( $user_id, $freeform, $url, $flags );
 
 		// Finally, let's wrap up everything in a container <span>.
 		$markup = $this->core->wrap_media_credit_markup( $credit, $include_schema_org );

--- a/includes/media-credit/components/class-shortcodes.php
+++ b/includes/media-credit/components/class-shortcodes.php
@@ -336,7 +336,7 @@ class Shortcodes implements \Media_Credit\Component {
 	 *     @type string $align      The alignment to use for the image/figure (if
 	 *                              used without `[caption]`).
 	 *     @type int    $width      The width of the image/figure in pixels.
-	 *     @type bool   $no_follow  A flag indicating that a `rel=nofollow`
+	 *     @type bool   $nofollow   A flag indicating that a `rel=nofollow`
 	 *                              attribute should be added to the link tag (if
 	 *                              `$url` is not empty).
 	 * }


### PR DESCRIPTION
Adds a filter hook to disable linkung to WordPress user pages by default. Fixes #98.