### PR TITLE
Housekeeping tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Media Credit #
 
-[![Build Status](https://travis-ci.org/mundschenk-at/media-credit.svg?branch=master)](https://travis-ci.org/mundschenk-at/media-credit)
+![Build Status](https://github.com/mundschenk-at/media-credit/actions/workflows/ci.yml/badge.svg)
 [![Latest Stable Version](https://poser.pugx.org/mundschenk-at/media-credit/v/stable)](https://packagist.org/packages/mundschenk-at/media-credit)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/mundschenk-at/media-credit/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/mundschenk-at/media-credit/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/mundschenk-at/media-credit/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/mundschenk-at/media-credit/?branch=master)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mundschenk-at_media-credit&metric=alert_status)](https://sonarcloud.io/dashboard?id=mundschenk-at_media-credit)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=mundschenk-at_media-credit&metric=coverage)](https://sonarcloud.io/dashboard?id=mundschenk-at_media-credit)
 [![License](https://poser.pugx.org/mundschenk-at/media-credit/license)](https://packagist.org/packages/mundschenk-at/media-credit)
 
 Adds a "Credit" field when uploading media to posts and displays it under the images on your blog to properly credit the artist.

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Adds a "Credit" field when uploading media to posts and displays it under the im
 ## Requirements ##
 
 *   PHP 7.0.0 or above
-*   WordPress 5.0 or above
+*   WordPress 5.2 or above

--- a/admin/js/media-credit-attachment-details.js
+++ b/admin/js/media-credit-attachment-details.js
@@ -132,14 +132,10 @@ jQuery( function( $ ) {
 			} );
 	};
 
+	/**
+	 * Extend Attachment Details view to include media credit fields.
+	 */
 	if ( wp.media.view.Attachment.Details ) {
-		/**
-		 * MediaCredit.AttachmentDetails
-		 *
-		 * @class
-		 * @augments wp.media.view.Attachment.Details
-		 * @augments wp.media.view.Attachment
-		 */
 		_.extend( wp.media.view.Attachment.Details.prototype, {
 
 			template: function( view ) {
@@ -152,8 +148,10 @@ jQuery( function( $ ) {
 
 				wp.media.view.Attachment.prototype.render.apply( this, [] );
 
+				// Add autocomplete to credit field.
 				$input = mediaCredit.autoComplete( this, 'label[data-setting="mediaCreditText"] input[type="text"]', true );
 
+				// Handle placeholders when author credits are disabled.
 				if ( noDefaultCredit ) {
 					$input.autocomplete( 'disable' );
 
@@ -179,15 +177,10 @@ jQuery( function( $ ) {
 		} );
 	}
 
+	/**
+	 * Extend Attachment Details TwoColumn view with media credit fields.
+	 */
 	if ( wp.media.view.Attachment.Details.TwoColumn ) {
-		/**
-		 * MediaCredit.AttachmentDetailsTwoColumn
-		 *
-		 * @class
-		 * @augments wp.media.view.Attachment.Details.TwoColumn
-		 * @augments wp.media.view.Attachment.Details
-		 * @augments wp.media.view.Attachment
-		 */
 		 _.extend( wp.media.view.Attachment.Details.TwoColumn.prototype, {
 
 			template: function( view ) {
@@ -204,13 +197,10 @@ jQuery( function( $ ) {
 		} );
 	}
 
+	/**
+	 * Extend Attachment model to handle changes to media credit fields.
+	 */
 	if ( wp.media.model.Attachment ) {
-		/**
-		 * MediaCredit.AttachmentModel
-		 *
-		 * @class
-		 * @augments wp.media.model.Attachment
-		 */
 		 _.extend( wp.media.model.Attachment.prototype, {
 
 			sync: function( method, model, options ) {
@@ -278,6 +268,14 @@ jQuery( function( $ ) {
 				return $.Deferred().rejectWith( this ).promise();
 			},
 
+			/**
+			 * Updates [media-credit] shortcodes in the current editor.
+			 *
+			 * @param  {string}         previousContent The editor content.
+			 * @param  {number}         attachmentId    The attachment ID to look for.
+			 * @param  {Backbone.Model} model           The attachment model containing
+			 *                                          the updated credit.
+			 */
 			updateMediaCreditInEditorContent: function( previousContent, attachmentId, model ) {
 				if ( previousContent ) {
 					wp.apiRequest( {

--- a/admin/js/media-credit-attachment-details.js
+++ b/admin/js/media-credit-attachment-details.js
@@ -202,8 +202,7 @@ jQuery( function( $ ) {
 		 _.extend( wp.media.model.Attachment.prototype, {
 			_sync: wp.media.model.Attachment.prototype.sync,
 			sync: function( method, model, options ) {
-				var result = null,
-					attachment,
+				var attachment,
 					attachmentId,
 					updatedMediaCredit = {};
 
@@ -260,8 +259,6 @@ jQuery( function( $ ) {
 				// Don't trigger AJAX call if there is nothing left to do.
 				if ( 'update' !== method || model.hasChanged() ) {
 					return this._sync( method, model, options );
-				} else if ( result ) {
-					return result;
 				}
 
 				return $.Deferred().rejectWith( this ).promise();

--- a/admin/js/media-credit-attachment-details.js
+++ b/admin/js/media-credit-attachment-details.js
@@ -1,7 +1,7 @@
 /**
  * This file is part of Media Credit.
  *
- * Copyright 2016-2020 Peter Putzer.
+ * Copyright 2016-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License,
@@ -140,7 +140,7 @@ jQuery( function( $ ) {
 		 * @augments wp.media.view.Attachment.Details
 		 * @augments wp.media.view.Attachment
 		 */
-		mediaCredit.AttachmentDetails = wp.media.view.Attachment.Details.extend( {
+		_.extend( wp.media.view.Attachment.Details.prototype, {
 
 			template: function( view ) {
 				return wp.media.template( 'attachment-details' )( view ) + wp.media.template( 'media-credit-attachment-details' )( view );
@@ -177,9 +177,6 @@ jQuery( function( $ ) {
 				wp.media.view.Attachment.prototype.updateSetting.apply( this, [ event ] );
 			},
 		} );
-
-		// Exchange prototype.
-		wp.media.view.Attachment.Details.prototype = mediaCredit.AttachmentDetails.prototype;
 	}
 
 	if ( wp.media.view.Attachment.Details.TwoColumn ) {
@@ -191,7 +188,7 @@ jQuery( function( $ ) {
 		 * @augments wp.media.view.Attachment.Details
 		 * @augments wp.media.view.Attachment
 		 */
-		mediaCredit.AttachmentDetailsTwoColumn = wp.media.view.Attachment.Details.TwoColumn.extend( {
+		 _.extend( wp.media.view.Attachment.Details.TwoColumn.prototype, {
 
 			template: function( view ) {
 				var templateHtml = $( $.parseHTML( wp.media.template( 'attachment-details-two-column' )( view ) ) );
@@ -205,9 +202,6 @@ jQuery( function( $ ) {
 				wp.media.view.Attachment.Details.prototype.updateSetting.apply( this, [ event ] );
 			},
 		} );
-
-		// Exchange prototype.
-		wp.media.view.Attachment.Details.TwoColumn.prototype = mediaCredit.AttachmentDetailsTwoColumn.prototype;
 	}
 
 	if ( wp.media.model.Attachment ) {
@@ -217,7 +211,7 @@ jQuery( function( $ ) {
 		 * @class
 		 * @augments wp.media.model.Attachment
 		 */
-		mediaCredit.AttachmentModel = wp.media.model.Attachment.extend( {
+		 _.extend( wp.media.model.Attachment.prototype, {
 
 			sync: function( method, model, options ) {
 				var result = null,
@@ -317,8 +311,5 @@ jQuery( function( $ ) {
 				}
 			},
 		} );
-
-		// Exchange prototype.
-		wp.media.model.Attachment.prototype = mediaCredit.AttachmentModel.prototype;
 	}
 } );

--- a/admin/js/media-credit-attachment-details.js
+++ b/admin/js/media-credit-attachment-details.js
@@ -142,11 +142,13 @@ jQuery( function( $ ) {
 				return wp.media.template( 'attachment-details' )( view ) + wp.media.template( 'media-credit-attachment-details' )( view );
 			},
 
+			_render: wp.media.view.Attachment.Details.prototype.render,
 			render: function() {
 				var $input,
 					noDefaultCredit = mediaCredit.options.noDefaultCredit || false;
 
-				wp.media.view.Attachment.prototype.render.apply( this, [] );
+				// Render template using superclass implementation.
+				this._render( this );
 
 				// Add autocomplete to credit field.
 				$input = mediaCredit.autoComplete( this, 'label[data-setting="mediaCreditText"] input[type="text"]', true );
@@ -164,6 +166,7 @@ jQuery( function( $ ) {
 				}
 			},
 
+			_updateSetting: wp.media.view.Attachment.Details.prototype.updateSetting,
 			updateSetting: function( event ) {
 				var $input = $( event.target );
 
@@ -172,7 +175,8 @@ jQuery( function( $ ) {
 					event.target.value = $input.prop( 'checked' ) ? 1 : 0;
 				}
 
-				wp.media.view.Attachment.prototype.updateSetting.apply( this, [ event ] );
+				// Update settings using superclass implementation.
+				this._updateSetting( event );
 			},
 		} );
 	}
@@ -182,17 +186,11 @@ jQuery( function( $ ) {
 	 */
 	if ( wp.media.view.Attachment.Details.TwoColumn ) {
 		 _.extend( wp.media.view.Attachment.Details.TwoColumn.prototype, {
-
 			template: function( view ) {
 				var templateHtml = $( $.parseHTML( wp.media.template( 'attachment-details-two-column' )( view ) ) );
 				$( wp.media.template( 'media-credit-attachment-details' )( view ) ).insertAfter( templateHtml.find( '.attachment-compat' ).prevAll( '*[data-setting]' )[0] );
 
 				return templateHtml;
-			},
-
-			updateSetting: function( event ) {
-				// If we don't override this here, the superclass updateSetting will never be called.
-				wp.media.view.Attachment.Details.prototype.updateSetting.apply( this, [ event ] );
 			},
 		} );
 	}
@@ -202,7 +200,7 @@ jQuery( function( $ ) {
 	 */
 	if ( wp.media.model.Attachment ) {
 		 _.extend( wp.media.model.Attachment.prototype, {
-
+			_sync: wp.media.model.Attachment.prototype.sync,
 			sync: function( method, model, options ) {
 				var result = null,
 					attachment,
@@ -261,10 +259,11 @@ jQuery( function( $ ) {
 
 				// Don't trigger AJAX call if there is nothing left to do.
 				if ( 'update' !== method || model.hasChanged() ) {
-					return this.constructor.__super__.sync.apply( this, [ method, model, options ] );
+					return this._sync( method, model, options );
 				} else if ( result ) {
 					return result;
 				}
+
 				return $.Deferred().rejectWith( this ).promise();
 			},
 

--- a/admin/js/tinymce4/media-credit-tinymce.js
+++ b/admin/js/tinymce4/media-credit-tinymce.js
@@ -358,9 +358,9 @@ tinymce.PluginManager.add( 'mediacredit', function( editor ) {
 					classes = ' class="' + classes + '"';
 				}
 
-				caption = caption.replace( /\r\n|\r/g, '\n' ).replace( /<[a-zA-Z0-9]+( [^<>]+)?>/g, function( a ) { // eslint-disable-line no-shadow
+				caption = caption.replace( /\r\n|\r/g, '\n' ).replace( /<[a-zA-Z0-9]+( [^<>]+)?>/g, function( _a ) {
 					// No line breaks inside HTML tags.
-					return a.replace( /[\r\n\t]+/, ' ' );
+					return _a.replace( /[\r\n\t]+/, ' ' );
 				} );
 
 				// Convert remaining line breaks to <br>.

--- a/admin/js/tinymce4/media-credit-tinymce.js
+++ b/admin/js/tinymce4/media-credit-tinymce.js
@@ -667,7 +667,8 @@ tinymce.PluginManager.add( 'mediacredit', function( editor ) {
 				dom.remove( imageNode.parentNode, true );
 			}
 		} else if ( imageData.linkUrl ) {
-			if ( linkNode = dom.getParent( imageNode, 'a' ) ) { // eslint-disable-line no-cond-assign
+			linkNode = dom.getParent( imageNode, 'a' );
+			if ( linkNode ) {
 				// The image is inside a link together with other nodes,
 				// or is nested in another node, move it out.
 				dom.insertAfter( imageNode, linkNode );

--- a/includes/media-credit-template.php
+++ b/includes/media-credit-template.php
@@ -25,6 +25,15 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+/**
+ * Warning message for invalid use of deprecated API functions.
+ *
+ * @internal
+ *
+ * @var string
+ */
+const MEDIA_CREDIT_ATTACHMENT_OBJECT_OR_ID_REQUIRED = 'You need to specify an attachment object or ID.';
+
 if ( ! function_exists( 'get_media_credit' ) ) {
 	/**
 	 * Template tag to return the media credit as plain text for some media attachment.
@@ -40,7 +49,7 @@ if ( ! function_exists( 'get_media_credit' ) ) {
 		_deprecated_function( __FUNCTION__, '4.0.0', 'Media_Credit::get_plaintext' );
 
 		if ( empty( $post ) ) {
-			_doing_it_wrong( __FUNCTION__, 'You need to specify an attachment object or ID.', '4.2.0' );
+			_doing_it_wrong( __FUNCTION__, \MEDIA_CREDIT_ATTACHMENT_OBJECT_OR_ID_REQUIRED, '4.2.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return '';
 		}
 
@@ -63,7 +72,7 @@ if ( ! function_exists( 'the_media_credit' ) ) {
 		_deprecated_function( __FUNCTION__, '4.0.0', 'Media_Credit::plaintext' );
 
 		if ( empty( $post ) ) {
-			_doing_it_wrong( __FUNCTION__, 'You need to specify an attachment object or ID.', '4.2.0' );
+			_doing_it_wrong( __FUNCTION__, \MEDIA_CREDIT_ATTACHMENT_OBJECT_OR_ID_REQUIRED, '4.2.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return;
 		}
 
@@ -86,7 +95,7 @@ if ( ! function_exists( 'get_media_credit_url' ) ) {
 		_deprecated_function( __FUNCTION__, '4.0.0', 'Media_Credit::get_url' );
 
 		if ( empty( $post ) ) {
-			_doing_it_wrong( __FUNCTION__, 'You need to specify an attachment object or ID.', '4.2.0' );
+			_doing_it_wrong( __FUNCTION__, \MEDIA_CREDIT_ATTACHMENT_OBJECT_OR_ID_REQUIRED, '4.2.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return '';
 		}
 
@@ -109,7 +118,7 @@ if ( ! function_exists( 'the_media_credit_url' ) ) {
 		_deprecated_function( __FUNCTION__, '4.0.0' );
 
 		if ( empty( $post ) ) {
-			_doing_it_wrong( __FUNCTION__, 'You need to specify an attachment object or ID.', '4.2.0' );
+			_doing_it_wrong( __FUNCTION__, \MEDIA_CREDIT_ATTACHMENT_OBJECT_OR_ID_REQUIRED, '4.2.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return;
 		}
 
@@ -132,7 +141,7 @@ if ( ! function_exists( 'get_media_credit_html' ) ) {
 		_deprecated_function( __FUNCTION__, '4.0.0', 'Media_Credit::get_html' );
 
 		if ( empty( $post ) ) {
-			_doing_it_wrong( __FUNCTION__, 'You need to specify an attachment object or ID.', '4.2.0' );
+			_doing_it_wrong( __FUNCTION__, \MEDIA_CREDIT_ATTACHMENT_OBJECT_OR_ID_REQUIRED, '4.2.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return '';
 		}
 
@@ -155,7 +164,7 @@ if ( ! function_exists( 'the_media_credit_html' ) ) {
 		_deprecated_function( __FUNCTION__, '4.0.0', 'Media_Credit::html' );
 
 		if ( empty( $post ) ) {
-			_doing_it_wrong( __FUNCTION__, 'You need to specify an attachment object or ID.', '4.2.0' );
+			_doing_it_wrong( __FUNCTION__, \MEDIA_CREDIT_ATTACHMENT_OBJECT_OR_ID_REQUIRED, '4.2.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return;
 		}
 

--- a/includes/media-credit-template.php
+++ b/includes/media-credit-template.php
@@ -38,7 +38,8 @@ if ( ! function_exists( 'get_media_credit' ) ) {
 	/**
 	 * Template tag to return the media credit as plain text for some media attachment.
 	 *
-	 * @since 4.0.0 The function has been deprecated in favor of Media_Credit::get_plaintext.
+	 * @deprecated 4.0.0 Deprecated in favor of `Media_Credit::get_plaintext`.
+	 *
 	 * @since 4.2.0 The parameter $post needs needs to be specified.
 	 *
 	 * @param  int|\WP_Post $post  An attachment ID or the corresponding \WP_Post object.
@@ -61,7 +62,8 @@ if ( ! function_exists( 'the_media_credit' ) ) {
 	/**
 	 * Template tag to print the media credit as plain text for some media attachment.
 	 *
-	 * @since 4.0.0 The function has been deprecated in favor of Media_Credit::plaintext.
+	 * @deprecated 4.0.0 Deprecated in favor of `Media_Credit::plaintext`.
+	 *
 	 * @since 4.2.0 The parameter $post needs needs to be specified.
 	 *
 	 * @param  int|\WP_Post $post  An attachment ID or the corresponding \WP_Post object.
@@ -84,7 +86,8 @@ if ( ! function_exists( 'get_media_credit_url' ) ) {
 	/**
 	 * Template tag to return the media credit URL as plain text for some media attachment.
 	 *
-	 * @since 4.0.0 The function has been deprecated in favor of Media_Credit::get_url.
+	 * @deprecated 4.0.0 Deprecated in favor of `Media_Credit::get_url`.
+	 *
 	 * @since 4.2.0 The parameter $post needs needs to be specified.
 	 *
 	 * @param  int|\WP_Post $post  An attachment ID or the corresponding \WP_Post object.
@@ -107,7 +110,8 @@ if ( ! function_exists( 'the_media_credit_url' ) ) {
 	/**
 	 * Template tag to print the media credit URL as plain text for some media attachment.
 	 *
-	 * @since  4.0.0 The function has been deprecated.
+	 * @deprecated 4.0.0
+	 *
 	 * @since  4.2.0 The parameter $post needs needs to be specified.
 	 *
 	 * @param  int|\WP_Post $post  An attachment ID or the corresponding \WP_Post object.
@@ -130,7 +134,8 @@ if ( ! function_exists( 'get_media_credit_html' ) ) {
 	/**
 	 * Template tag to return the media credit as HTML with a link to the author page if one exists for some media attachment.
 	 *
-	 * @since  4.0.0 The function has been deprecated in favor of Media_Credit::get_html.
+	 * @deprecated 4.0.0 Deprecated in favor of `Media_Credit::get_html`.
+	 *
 	 * @since  4.2.0 The parameter $post needs needs to be specified.
 	 *
 	 * @param  int|\WP_Post $post An attachment ID or the corresponding \WP_Post object.
@@ -153,7 +158,8 @@ if ( ! function_exists( 'the_media_credit_html' ) ) {
 	/**
 	 * Template tag to print the media credit as HTML with a link to the author page if one exists for some media attachment.
 	 *
-	 * @since  4.0.0 The function has been deprecated in favor of Media_Credit::html.
+	 * @deprecated 4.0.0 Deprecated in favor of `Media_Credit::html`.
+	 *
 	 * @since  4.2.0 The parameter $post needs needs to be specified.
 	 *
 	 * @param  int|\WP_Post $post  An attachment ID or the corresponding \WP_Post object.
@@ -176,7 +182,7 @@ if ( ! function_exists( 'get_media_credit_html_by_user_id' ) ) {
 	/**
 	 * Template tag to return the media credit as HTML with a link to the author page if one exists for a WordPress user.
 	 *
-	 * @since  4.0.0 The function has been deprecated in favor of Media_Credit::get_html_by_user_id.
+	 * @deprecated 4.0.0 Deprecated in favor of `Media_Credit::get_html_by_user_id`.
 	 *
 	 * @param  int $id User ID of a WordPress user.
 	 *
@@ -193,7 +199,7 @@ if ( ! function_exists( 'the_media_credit_html_by_user_id' ) ) {
 	/**
 	 * Template tag to print the media credit as HTML with a link to the author page if one exists for a WordPress user.
 	 *
-	 * @since  4.0.0 The function has been deprecated in favor of Media_Credit::html_by_user_id.
+	 * @deprecated 4.0.0 Deprecated in favor of `Media_Credit::html_by_user_id`.
 	 *
 	 * @param  int $id User ID of a WordPress user.
 	 *
@@ -211,7 +217,7 @@ if ( ! function_exists( 'display_author_media' ) ) {
 	/**
 	 * Template tag to display the recently added media attachments for given author.
 	 *
-	 * @since  4.0.0 The function has been deprecated in favor of Media_Credit::display_author_media.
+	 * @deprecated 4.0.0 Deprecated in favor of `Media_Credit::display_author_media`.
 	 *
 	 * @param  int    $author_id           The user ID of the author.
 	 * @param  bool   $sidebar             Display as sidebar or inline. Optional. Default true.
@@ -245,7 +251,7 @@ if ( ! function_exists( 'author_media_and_posts' ) ) {
 	/**
 	 * Template tag to return the recently added media attachments and posts for a given author.
 	 *
-	 * @since  4.0.0 The function has been deprecated in favor of Media_Credit::author_media_and_posts.
+	 * @deprecated 4.0.0 Deprecated in favor of `Media_Credit::author_media_and_posts`.
 	 *
 	 * @param  int  $author_id          A user ID.
 	 * @param  bool $include_posts      Optional. A flag indicating whether posts (as well as attachments) should be included in the results. Default false.
@@ -272,7 +278,7 @@ if ( ! function_exists( 'author_media' ) ) {
 	/**
 	 * Returns the recently added media attachments for a given author.
 	 *
-	 * @since  4.0.0 The function has been deprecated in favor of Media_Credit::author_media_and_posts.
+	 * @deprecated 4.0.0 Deprecated in favor of `Media_Credit::author_media_and_posts`.
 	 *
 	 * @param  int  $author_id          A user ID.
 	 * @param  int  $limit              Optional. The upper limit to the number of returned posts. Default 0 (no limit).

--- a/includes/media-credit/components/class-classic-editor.php
+++ b/includes/media-credit/components/class-classic-editor.php
@@ -249,7 +249,12 @@ class Classic_Editor implements \Media_Credit\Component {
 		// Put it all together.
 		$shortcode = "[media-credit {$shortcode_arguments}]{$html}[/media-credit]";
 
-		// @todo Document filter.
+		/**
+		 * Filters the shortcode tag sent to the editor.
+		 *
+		 * @param string $shortcode The shortcode tag (including the image markup).
+		 * @param string $html      The image HTML markup to send.
+		 */
 		return \apply_filters( 'media_add_credit_shortcode', $shortcode, $html );
 	}
 }

--- a/includes/media-credit/components/class-media-library.php
+++ b/includes/media-credit/components/class-media-library.php
@@ -99,7 +99,7 @@ class Media_Library implements \Media_Credit\Component {
 	 */
 	public function run() {
 		// Initialize admin-only parts.
-		\add_action( 'admin_init',            [ $this, 'admin_init' ] );
+		\add_action( 'admin_init',            [ $this, 'show_credit_in_media_list_view' ] );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 
 		// Add default credit to new attachments.
@@ -203,11 +203,11 @@ class Media_Library implements \Media_Credit\Component {
 	/**
 	 * Ensures that proper attachment credits are shown on the admin side of WordPress.
 	 *
-	 * @todo Rename to show_credit_in_media_list_view.
+	 * @since 4.2.0 Renamed from `admin_init`.`
 	 *
 	 * @return void
 	 */
-	public function admin_init() {
+	public function show_credit_in_media_list_view() {
 		// Filter the_author using this method so that freeform media credit is correctly displayed in Media Library.
 		\add_filter( 'the_author', [ $this, 'filter_the_author' ] );
 	}

--- a/includes/media-credit/tools/class-shortcodes-filter.php
+++ b/includes/media-credit/tools/class-shortcodes-filter.php
@@ -70,7 +70,14 @@ class Shortcodes_Filter {
 			}
 
 			// Replace the old shortcode with then new one.
-			$content = $this->update_shortcode( $content, $shortcode[0], $this->parse_shortcode_attributes( $shortcode[3] ), $img, $author_id, $freeform, $url, $nofollow );
+			$attr    = $this->parse_shortcode_attributes( $shortcode[3] );
+			$updated = [
+				'id'       => $author_id,
+				'name'     => $freeform,
+				'link'     => $url,
+				'nofollow' => $nofollow,
+			];
+			$content = $this->update_shortcode( $content, $shortcode[0], $img, $attr, $updated );
 		}
 
 		return $content;
@@ -83,40 +90,44 @@ class Shortcodes_Filter {
 	 *
 	 * @param  string $content    The current post content.
 	 * @param  string $shortcode  The shortcode to update.
+	 * @param  string $img        The contained `<img>` tag.
 	 * @param  array  $attr {
-	 *     The parsed shortcode attributes. All attributes are optional.
+	 *     The parsed shortcode attributes. All attributes are optional. Additional
+	 *     attributes not listed here will be preserved in the output.
 	 *
 	 *     @type int    $id       The author ID.
 	 *     @type string $name     The freeform credit.
 	 *     @type string $url      The credit URL.
 	 *     @type bool   $nofollow The "rel=nofollow" flag.
 	 * }
-	 * @param  string $img        The contained `<img>` tag.
-	 * @param  int    $author_id  The new author ID.
-	 * @param  string $freeform   The new freeform credit.
-	 * @param  string $url        The new credit URL.
-	 * @param  bool   $nofollow   The new "rel=nofollow" flag.
+	 * @param  array  $updated {
+	 *     The shortcode attributes to update. All attributes are mandatory.
+	 *
+	 *     @type int    $id       The author ID.
+	 *     @type string $name     The freeform credit.
+	 *     @type string $url      The credit URL.
+	 *     @type bool   $nofollow The "rel=nofollow" flag.
+	 * }
 	 *
 	 * @return string             The updated post content.
 	 */
-	protected function update_shortcode( string $content, string $shortcode, array $attr, string $img, int $author_id, string $freeform, string $url, bool $nofollow ) {
-
+	protected function update_shortcode( string $content, string $shortcode, string $img, array $attr, array $updated ) {
 		// Drop the old id/name attributes (if any).
 		unset( $attr['id'] );
 		unset( $attr['name'] );
 
 		// Prefer author ID if present & valid.
-		$id_or_name = $author_id > 0 ? "id={$author_id}" : "name=\"{$freeform}\"";
+		$id_or_name = $updated['id'] > 0 ? "id={$updated['id']}" : "name=\"{$updated['name']}\"";
 
 		// Update link attribute.
-		if ( ! empty( $url ) ) {
-			$attr['link'] = $url;
+		if ( ! empty( $updated['link'] ) ) {
+			$attr['link'] = $updated['link'];
 		} else {
 			unset( $attr['link'] );
 		}
 
 		// Update nofollow attribute.
-		if ( ! empty( $url ) && ! empty( $nofollow ) ) {
+		if ( ! empty( $updated['link'] ) && ! empty( $updated['nofollow'] ) ) {
 			$attr['nofollow'] = true;
 		} else {
 			unset( $attr['nofollow'] );

--- a/tests/Media_Credit/Components/Media_Library_Test.php
+++ b/tests/Media_Credit/Components/Media_Library_Test.php
@@ -126,7 +126,7 @@ class Media_Library_Test extends TestCase {
 	 * @covers ::run
 	 */
 	public function test_run() {
-		Actions\expectAdded( 'admin_init' )->once()->with( [ $this->sut, 'admin_init' ] );
+		Actions\expectAdded( 'admin_init' )->once()->with( [ $this->sut, 'show_credit_in_media_list_view' ] );
 		Actions\expectAdded( 'admin_enqueue_scripts' )->once()->with( [ $this->sut, 'enqueue_scripts_and_styles' ] );
 
 		Actions\expectAdded( 'add_attachment' )->once()->with( [ $this->sut, 'add_default_media_credit_for_attachment' ] );
@@ -259,14 +259,14 @@ class Media_Library_Test extends TestCase {
 	}
 
 	/**
-	 * Tests ::admin_init.
+	 * Tests ::show_credit_in_media_list_view.
 	 *
-	 * @covers ::admin_init
+	 * @covers ::show_credit_in_media_list_view
 	 */
-	public function test_admin_init() {
+	public function test_show_credit_in_media_list_view() {
 		Filters\expectAdded( 'the_author' )->once()->with( [ $this->sut, 'filter_the_author' ] );
 
-		$this->assertNull( $this->sut->admin_init() );
+		$this->assertNull( $this->sut->show_credit_in_media_list_view() );
 	}
 
 	/**

--- a/tests/Media_Credit/Tools/Shortcodes_Filter_Test.php
+++ b/tests/Media_Credit/Tools/Shortcodes_Filter_Test.php
@@ -133,6 +133,12 @@ HTML;
 			'align' => 'alignright',
 			'width' => '150',
 		];
+		$updated        = [
+			'id'       => $author_id,
+			'name'     => $freeform,
+			'link'     => $url,
+			'nofollow' => $nofollow,
+		];
 
 		// Expected result.
 		$updated_content = 'CONTENT WITH UPDATED SHORTCODES';
@@ -144,7 +150,7 @@ HTML;
 		$this->sut->shouldReceive( 'parse_shortcode_attributes' )->once()->with( m::type( 'string' ) )->andReturn( $attr );
 		$this->sut->shouldReceive( 'update_shortcode' )
 			->once()
-			->with( self::CONTENT, m::pattern( '/\[media-credit.*\[\/media-credit\]/' ), $attr, m::type( 'string' ), $author_id, $freeform, $url, $nofollow )
+			->with( self::CONTENT, m::pattern( '/\[media-credit.*\[\/media-credit\]/' ), m::type( 'string' ), $attr, $updated )
 			->andReturn( $updated_content );
 
 		$this->assertSame( $updated_content, $this->sut->update_changed_media_credits( self::CONTENT, $image_id, $author_id, $freeform, $url, $nofollow ) );
@@ -188,10 +194,12 @@ HTML;
 					'foo'      => 'bar',
 					'nofollow' => false,
 				],
-				5,
-				'',
-				'https://example.net/my/url',
-				true,
+				[
+					'id'       => 5,
+					'name'     => '',
+					'link'     => 'https://example.net/my/url',
+					'nofollow' => true,
+				],
 				'id=5 link="https://example.net/my/url" foo="bar" nofollow="1"',
 			],
 			[
@@ -202,10 +210,12 @@ HTML;
 					'foo'      => 'bar',
 					'nofollow' => false,
 				],
-				0,
-				'Foobar',
-				'',
-				true,
+				[
+					'id'       => 0,
+					'name'     => 'Foobar',
+					'link'     => '',
+					'nofollow' => true,
+				],
 				'name="Foobar" foo="bar"',
 			],
 			[
@@ -216,10 +226,12 @@ HTML;
 					'foo'      => 'bar',
 					'nofollow' => true,
 				],
-				5,
-				'',
-				'https://example.net/my/url',
-				false,
+				[
+					'id'       => 5,
+					'name'     => '',
+					'link'     => 'https://example.net/my/url',
+					'nofollow' => false,
+				],
 				'id=5 link="https://example.net/my/url" foo="bar"',
 			],
 		];
@@ -232,15 +244,12 @@ HTML;
 	 *
 	 * @dataProvider provide_update_shortcode_data
 	 *
-	 * @param  array  $attr      The current shortcode attributes.
-	 * @param  int    $author_id The new author ID.
-	 * @param  string $freeform  The new freeform credit.
-	 * @param  string $url       The new credit URL.
-	 * @param  bool   $nofollow  The new nofollow flag.
-	 * @param  string $result    The new shortcode attribute string as part of the
-	 *                           expected result.
+	 * @param  array  $attr    The current shortcode attributes.
+	 * @param  array  $updated The updated shortcode attributes.
+	 * @param  string $result  The new shortcode attribute string as part of the
+	 *                         expected result.
 	 */
-	public function test_update_shortcode( array $attr, $author_id, $freeform, $url, $nofollow, $result ) {
+	public function test_update_shortcode( array $attr, $updated, $result ) {
 		// Input data.
 		$content   = 'fake content [MEDIACREDIT] more fake content';
 		$shortcode = '[MEDIACREDIT]';
@@ -249,7 +258,7 @@ HTML;
 		// Expected result.
 		$result = "fake content [media-credit {$result}]{$img}[/media-credit] more fake content";
 
-		$this->assertSame( $result, $this->sut->update_shortcode( $content, $shortcode, $attr, $img, $author_id, $freeform, $url, $nofollow ) );
+		$this->assertSame( $result, $this->sut->update_shortcode( $content, $shortcode, $img, $attr, $updated ) );
 	}
 
 	/**


### PR DESCRIPTION
- Updates `README.md`  badges.
- Cleans up PHPDoc annotations.
- Adds a constant for `_doing_it_wrong` messages in legacy `media-credit-template.html`.
- Renames `Media_Credit\Components\Media_Libary::admin_init` to `::show_credit_in_media_list_view`.
- Reduces the number of parameters of `Media_Credit\Tools\Shortcodes_Filter::update_shortcode` to a sane level.
- Updates JavaScript implementation to work with WordPress newer than 5.3 (was not working with 5.7, 5.4-5.6 not tested).