### PR TITLE
Release 4.2.0

### DIFF
--- a/.scoper.inc.php
+++ b/.scoper.inc.php
@@ -100,9 +100,7 @@ return [
     // Whitelists a list of files. Unlike the other whitelist related features, this one is about completely leaving
     // a file untouched.
     // Paths are relative to the configuration file unless if they are already absolute
-    'files-whitelist' => [
-        'vendor/mundschenk-at/check-wp-requirements/class-mundschenk-wp-requirements.php',
-    ],
+    'files-whitelist' => [],
 
     // When scoping PHP files, there will be scenarios where some of the code being scoped indirectly references the
     // original namespace. These will include, for example, strings or string manipulations. PHP-Scoper has limited

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog #
 
-## 4.2.0 (unreleased) ##
+## 4.2.0 (July 22, 2021) ##
 *   _Feature_: A shorter label for credits displayed at the end of a post can be
     enabled via the new filter hook `media_credit_at_end_use_short_label` (`Images:`
     instead of `Images courtesy of`).
 *   _Feature_: The automatic linking of user credits to the WordPress author page
     can be disabled with the new filter hook `media_credit_disable_author_urls`.
+*   _Feature_: Media Credit is now fully compatible with PHP 8.0.
 *   _Bugfix_: The credit overlay cannot be selected any more by accident in the
     classic editor.
 *   _Bugfix_: Several visual glitches in classic editor have been fixed and parsing
@@ -14,10 +15,15 @@
     image properties in the classic editor.
 *   _Bugfix_: Organization and separator are set correctly when adding a user credit
     via the image properties dialogue in the classic editor.
-*   _Bugfix_: Credits can be deliberately set to empty again when credits to Wordpress
-    authors are enabled (broken since 4.0.0).
+*   _Bugfix_: Autocomplete works realiably again in Media Library.
+*   _Bugfix_: Credits can be deliberately set to be empty again when credits to
+    Wordpress authors are enabled (had been broken since 4.0.0).
+*   _Bugfix_: No more `Notice: register_rest_route was called incorrectly` during
+    plugin initialization.
 *   _Change_: WordPress minimum version increased to 5.2.0.
 *   _Change_: PHP minimum version increased to 7.0.0.
+*   _Change_: Support for Internet Explorer 11 has been dropped.
+*   _Change_: A fabulous new plugin icon designed by [Johanna Amann](https://www.instagram.com/_jo_am/).
 
 ## 4.1.1 (December 10, 2020) ##
 *   _Bugfix_: Credits containing apostrophes can be edited in the legacy Media Library view.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,7 +94,7 @@ module.exports = function( grunt ) {
 						files: [ {
 								expand: true,
 								flatten: false,
-								src: ['build/includes/class-media-credit-factory.php'],
+								src: ['build/includes/media-credit/class-factory.php'],
 								dest: '',
 						} ]
 				},

--- a/media-credit.php
+++ b/media-credit.php
@@ -28,7 +28,7 @@
  * Plugin Name:       Media Credit
  * Plugin URI:        https://code.mundschenk.at/media-credit/
  * Description:       This plugin adds a "Credit" field to the media uploading and editing tool and inserts this credit when the images appear on your blog.
- * Version:           4.2.0-alpha.1
+ * Version:           4.2.0
  * Requires at least: 5.2
  * Requires PHP:      7.0
  * Author:            Peter Putzer

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,22 @@ Feel free to get in touch with us about anything you'd like us to add to this li
 
 == Changelog ==
 
+= 4.2.0 (July 22, 2021) =
+* _Feature_: A shorter label for credits displayed at the end of a post can be enabled via the new filter hook `media_credit_at_end_use_short_label` (`Images:` instead of `Images courtesy of`).
+* _Feature_: The automatic linking of user credits to the WordPress author page can be disabled with the new filter hook `media_credit_disable_author_urls`.
+* _Feature_: Media Credit is now fully compatible with PHP 8.0.
+* _Bugfix_: The credit overlay cannot be selected any more by accident in the classic editor.
+* _Bugfix_: Several visual glitches in classic editor have been fixed and parsing has been made more robust.
+* _Bugfix_: Credit width is set properly for custom image sizes when editing image properties in the classic editor.
+* _Bugfix_: Organization and separator are set correctly when adding a user credit via the image properties dialogue in the classic editor.
+* _Bugfix_: Autocomplete works reliably again in Media Library.
+* _Bugfix_: Credits can be deliberately set to be empty again when credits to Wordpress authors are enabled (had been broken since 4.0.0).
+* _Bugfix_: No more `Notice: register_rest_route was called incorrectly` during plugin initialization.
+* _Change_: WordPress minimum version increased to 5.2.0.
+* _Change_: PHP minimum version increased to 7.0.0.
+* _Change_: Support for Internet Explorer 11 has been dropped.
+* _Change_: A fabulous new plugin icon designed by [Johanna Amann](https://www.instagram.com/_jo_am/).
+
 = 4.1.1 (December 10, 2020) =
 * _Bugfix_: Credits containing apostrophes can be edited in the legacy Media Library view.
 * _Bugfix_: Changes to `nofollow` flag are now saved in the legacy Media Library view as well.

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Media Credit ===
 Contributors: pputzer, sbressler
 Tags: media, image, images, credit, byline, author, user
-Tested up to: 5.7
-Stable tag: 4.1.1
+Tested up to: 5.8
+Stable tag: 4.2.0
 License: GPLv2 or later
 
 Adds a "Credit" field when uploading media to posts and displays it under the images on your blog to properly credit the artist.


### PR DESCRIPTION
- Updates `CHANGELOG`.
- Bumps version to `4.2.0`.
- Sets `Tested up to` to `5.8`.
- Fixes a glitch in the build process (because `Media_Credit_Factory` was moved to.`Media_Credit\Factory`).