### PR TITLE
Update to current WordPress standards

### DIFF
--- a/admin/js/media-credit-attachment-details.js
+++ b/admin/js/media-credit-attachment-details.js
@@ -1,7 +1,7 @@
 /**
  * This file is part of Media Credit.
  *
- * Copyright 2016-2021 Peter Putzer.
+ * Copyright 2016-2023 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License,
@@ -22,8 +22,6 @@
  * @author Peter Putzer <github@mundschenk.at>
  * @since  3.1.0
  */
-
-/* global: wp, _, tinymce, mundschenk */ // Scrutinizer-CI
 
 jQuery( function( $ ) {
 	'use strict';

--- a/admin/js/media-credit-legacy-autocomplete.js
+++ b/admin/js/media-credit-legacy-autocomplete.js
@@ -1,7 +1,7 @@
 /**
  * This file is part of Media Credit.
  *
- * Copyright 2013-2020 Peter Putzer.
+ * Copyright 2013-2023 Peter Putzer.
  * Copyright 2010-2011 Scott Bressler.
  *
  * This program is free software; you can redistribute it and/or
@@ -23,8 +23,6 @@
  * @author Scott Bressler
  * @since  0.5.1
  */
-
-/* global: _, mundschenk */ // Scrutinizer-CI
 
 jQuery( function( $ ) {
 	'use strict';

--- a/admin/js/tinymce4/media-credit-image-properties.js
+++ b/admin/js/tinymce4/media-credit-image-properties.js
@@ -1,7 +1,7 @@
 /**
  * This file is part of Media Credit.
  *
- * Copyright 2014-2021 Peter Putzer.
+ * Copyright 2014-2023 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License,
@@ -22,8 +22,6 @@
  * @author Peter Putzer <github@mundschenk.at>
  * @since  2.3.0
  */
-
-/* global: wp, mundschenk */ // Scrutinizer-CI
 
 ( function( $, wp, mundschenk ) {
 	'use strict';
@@ -85,7 +83,7 @@
 	} );
 
 	/**
-	 * Update TinyMCE HTML represenation of media credit.
+	 * Update TinyMCE HTML representation of media credit.
 	 */
 	wp.media.events.on( 'editor:image-update', function( options ) {
 		var editor = options.editor,

--- a/admin/js/tinymce4/media-credit-tinymce-switch.js
+++ b/admin/js/tinymce4/media-credit-tinymce-switch.js
@@ -1,8 +1,8 @@
 /**
  * This file is part of Media Credit.
  *
- * Copyright 2013-2020 Peter Putzer.
- * Copyright 2003-2020 The WordPress contributors.
+ * Copyright 2013-2023 Peter Putzer.
+ * Copyright 2003-2021 The WordPress contributors.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License,
@@ -24,7 +24,7 @@
  */
 
 /**
- * Based on revision @48650 of https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/wp/editor/base.js (removep)
+ * Based on revision @51768 of https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/wp/editor/base.js (removep)
  *
  * The version number in the "@since" tags below mean WordPress versions.
  */

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "^3.0",
-		"wp-coding-standards/wpcs": "^2.0",
+		"wp-coding-standards/wpcs": "dev-develop",
 		"phpcompatibility/phpcompatibility-wp": "^2.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
 		"roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
 	"prefer-stable": true,
 	"scripts": {
 		"phpcs": [
-			"phpcs -p -s includes/ admin/ public/ --extensions=php --ignore=*.asset.php"
+			"phpcs -p -s includes/ admin/ public/ media-credit.php uninstall.php --extensions=php --ignore=*.asset.php"
 		],
 		"test": [
 			"phpunit --testsuite MediaCredit"

--- a/includes/media-credit-template.php
+++ b/includes/media-credit-template.php
@@ -126,7 +126,7 @@ if ( ! function_exists( 'the_media_credit_url' ) ) {
 			return;
 		}
 
-		echo \esc_url_raw( \get_media_credit_url( $post ) );
+		echo \sanitize_url( \get_media_credit_url( $post ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- sanitize_url is currently not recognized properly.
 	}
 }
 

--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -670,7 +670,7 @@ class Core {
 			} else {
 				// Free-form text was entered, insert postmeta with credit.
 				// if free-form text is blank, insert a single space in postmeta.
-				$freeform = $freeform ?: self::EMPTY_META_STRING; // phpcs:ignore WordPress.PHP.DisallowShortTernary
+				$freeform = $freeform ?: self::EMPTY_META_STRING; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 				\update_post_meta( $attachment->ID, self::POSTMETA_KEY, $freeform );
 
 				// User ID stays untouched.

--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -297,7 +297,7 @@ class Core {
 					if ( ! \is_string( $meta_value ) ) {
 						$meta_value = '';
 					} else {
-						$meta_value = \esc_url_raw( $meta_value );
+						$meta_value = \sanitize_url( $meta_value );
 					}
 					break;
 

--- a/includes/media-credit/class-core.php
+++ b/includes/media-credit/class-core.php
@@ -321,8 +321,14 @@ class Core {
 	 * @return string            The freeform credit (or the empty string).
 	 */
 	protected function get_media_credit_freeform_text( $attachment_id ) {
+		/**
+		 * Retrieve the post meta containing the freeform credit. Default is an empty string.
+		 *
+		 * @phpstan-var string $meta_value
+		 */
 		$meta_value = \get_post_meta( $attachment_id, self::POSTMETA_KEY, true );
 
+		// Always return string (it shouldn't ever be any other type, but we want to be certain).
 		return \is_string( $meta_value ) ? $meta_value : '';
 	}
 
@@ -334,8 +340,14 @@ class Core {
 	 * @return string            The credit URL (or the empty string if none is set).
 	 */
 	protected function get_media_credit_url( $attachment_id ) {
+		/**
+		 * Retrieve the post meta containing the credit URL. Default is an empty string.
+		 *
+		 * @phpstan-var string $meta_value
+		 */
 		$meta_value = \get_post_meta( $attachment_id, self::URL_POSTMETA_KEY, true );
 
+		// Always return string (it shouldn't ever be any other type, but we want to be certain).
 		return \is_string( $meta_value ) ? $meta_value : '';
 	}
 
@@ -354,14 +366,14 @@ class Core {
 	 */
 	protected function get_media_credit_data( $attachment_id ) {
 		/**
-		 * PHPStan type.
+		 * Retrieve the post meta containing the flags array. Default is an empty array.
 		 *
-		 * @phpstan-var MediaCreditFlags|false $meta_value
+		 * @phpstan-var MediaCreditFlags $meta_value
 		 */
 		$meta_value = \get_post_meta( $attachment_id, self::DATA_POSTMETA_KEY, true );
 
 		// Always return an array (it shouldn't be a scalar, but we want to be certain).
-		return ( $meta_value ? (array) $meta_value : [] );
+		return \is_array( $meta_value ) ? $meta_value : [];
 	}
 
 	/**

--- a/includes/media-credit/class-settings.php
+++ b/includes/media-credit/class-settings.php
@@ -338,7 +338,7 @@ class Settings {
 					'short'          => \__( 'Organization', 'media-credit' ),
 					'help_text'      => \__( 'Organization used when crediting media to users of this blog.', 'media-credit' ),
 					'attributes'     => [ 'class' => 'regular-text' ],
-					'default'        => \get_bloginfo( 'name', 'display' ),
+					'default'        => \get_bloginfo( 'name' ),
 				],
 				self::CREDIT_AT_END             => [
 					'ui'               => Controls\Checkbox_Input::class,

--- a/includes/media-credit/components/class-rest-api.php
+++ b/includes/media-credit/components/class-rest-api.php
@@ -38,6 +38,7 @@ use Media_Credit\Tools\Shortcodes_Filter;
  * @since 4.2.0 The public method sanitize_text_field has been deprecated.
  *
  * @phpstan-import-type MediaCreditJSONRaw from Core
+ * @phpstan-type MediaCreditRESTRequest array{content: string, attachment_id: int, author_id: int, freeform: string, url: string, nofollow: bool}
  */
 class REST_API implements \Media_Credit\Component {
 
@@ -283,6 +284,8 @@ class REST_API implements \Media_Credit\Component {
 	 * @param  \WP_REST_Request $request The REST request.
 	 *
 	 * @return \WP_REST_Response
+	 *
+	 * @phpstan-param \WP_REST_Request<MediaCreditRESTRequest> $request
 	 */
 	public function rest_filter_content( \WP_REST_Request $request ) {
 

--- a/includes/media-credit/components/class-setup.php
+++ b/includes/media-credit/components/class-setup.php
@@ -149,6 +149,7 @@ class Setup implements \Media_Credit\Component {
 			[
 				'object_subtype'    => 'attachment',
 				'type'              => 'string',
+				'default'           => '',
 				'description'       => 'The copyright line itself (if not overridden by the `user_id`)',
 				'single'            => true,
 				'sanitize_callback' => [ $this->core, 'sanitize_media_credit_meta_field' ],
@@ -162,6 +163,7 @@ class Setup implements \Media_Credit\Component {
 			[
 				'object_subtype'    => 'attachment',
 				'type'              => 'string',
+				'default'           => '',
 				'description'       => 'A URL to link from the copyright information (overriding the default link to author pages)',
 				'single'            => true,
 				'sanitize_callback' => [ $this->core, 'sanitize_media_credit_meta_field' ],
@@ -175,6 +177,7 @@ class Setup implements \Media_Credit\Component {
 			[
 				'object_subtype'    => 'attachment',
 				'type'              => 'array',
+				'default'           => [],
 				'description'       => 'Optional flags for the copyright information (or the link)',
 				'single'            => true,
 				'sanitize_callback' => [ $this->core, 'sanitize_media_credit_meta_field' ],

--- a/includes/media-credit/components/class-shortcodes.php
+++ b/includes/media-credit/components/class-shortcodes.php
@@ -447,7 +447,7 @@ class Shortcodes implements \Media_Credit\Component {
 		// Sanitize attribute values.
 		$atts['id']         = \absint( $atts['id'] );
 		$atts['name']       = \sanitize_text_field( $atts['name'] );
-		$atts['link']       = \esc_url_raw( $atts['link'] );
+		$atts['link']       = \sanitize_url( $atts['link'] );
 		$atts['standalone'] = \filter_var( $atts['standalone'], \FILTER_VALIDATE_BOOLEAN );
 		$atts['align']      = \sanitize_html_class( $atts['align'] );
 		$atts['width']      = \absint( $atts['width'] );

--- a/includes/media-credit/components/class-shortcodes.php
+++ b/includes/media-credit/components/class-shortcodes.php
@@ -261,7 +261,7 @@ class Shortcodes implements \Media_Credit\Component {
 
 		if ( ! empty( $this->settings->get( Settings::CREDIT_AT_END ) ) ) {
 			// Disable shortcode if credits should be shown after the post content.
-			return \do_shortcode( $content );
+			return \apply_shortcodes( $content );
 		}
 
 		// Make sure that $atts really is an array, might be an empty string in some edge cases.
@@ -326,7 +326,7 @@ class Shortcodes implements \Media_Credit\Component {
 
 		// Required template variables.
 		$args = [
-			'content'             => \do_shortcode( $content ), // expand nested shortcodes.
+			'content'             => \apply_shortcodes( $content ), // expand nested shortcodes.
 			'html5'               => $html5,
 			'schema_org'          => ! empty( $this->settings->get( Settings::SCHEMA_ORG_MARKUP ) ),
 			'width'               => $width,

--- a/includes/media-credit/tools/class-author-query.php
+++ b/includes/media-credit/tools/class-author-query.php
@@ -95,14 +95,21 @@ class Author_Query {
 	 */
 	protected function get_author_list_query() {
 		$query = [
-			'who' => 'authors',
+			'capability' => 'edit_posts',
 		];
+
+		// Capability queries were only introduced in WordPress 5.9.
+		if ( \version_compare( \get_bloginfo( 'version' ), '5.9-alpha', '<' ) ) {
+			$query['who'] = 'authors';
+			unset( $query['capability'] );
+		}
 
 		/**
 		 * Filters the query for retrieving the list of users eligible to be used
 		 * in media credits.
 		 *
 		 * @since 4.1.0
+		 * @since 4.3.0 The query uses `'capability' => 'edit_posts'` on WordPress 5.9 and higher.
 		 *
 		 * @param array $query {
 		 *     A partial user query (@see WP_User_Query::prepare_query for possibilities).
@@ -111,7 +118,8 @@ class Author_Query {
 		 *     and display names. Any `orderby`, `number`, `offset`, `count_total`,
 		 *     and `fields` clauses set here will be ignored.
 		 *
-		 *     string $who Default 'authors'.
+		 *     string $capability Optional. Default 'edit_posts' (only on WordPress 5.9+).
+		 *     string $who        Optional. Default 'authors' (only on WordPress < 5.9).
 		 * }
 		 */
 		$query = \apply_filters( 'media_credit_author_list_query', $query );

--- a/includes/media-credit/tools/class-author-query.php
+++ b/includes/media-credit/tools/class-author-query.php
@@ -98,18 +98,12 @@ class Author_Query {
 			'capability' => 'edit_posts',
 		];
 
-		// Capability queries were only introduced in WordPress 5.9.
-		if ( \version_compare( \get_bloginfo( 'version' ), '5.9-alpha', '<' ) ) {
-			$query['who'] = 'authors';
-			unset( $query['capability'] );
-		}
-
 		/**
 		 * Filters the query for retrieving the list of users eligible to be used
 		 * in media credits.
 		 *
 		 * @since 4.1.0
-		 * @since 4.3.0 The query uses `'capability' => 'edit_posts'` on WordPress 5.9 and higher.
+		 * @since 4.3.0 The query uses `'capability' => 'edit_posts'` now (requiring at least WordPress 5.9).
 		 *
 		 * @param array $query {
 		 *     A partial user query (@see WP_User_Query::prepare_query for possibilities).
@@ -118,8 +112,7 @@ class Author_Query {
 		 *     and display names. Any `orderby`, `number`, `offset`, `count_total`,
 		 *     and `fields` clauses set here will be ignored.
 		 *
-		 *     string $capability Optional. Default 'edit_posts' (only on WordPress 5.9+).
-		 *     string $who        Optional. Default 'authors' (only on WordPress < 5.9).
+		 *     string $capability Optional. Default 'edit_posts'.
 		 * }
 		 */
 		$query = \apply_filters( 'media_credit_author_list_query', $query );

--- a/media-credit.php
+++ b/media-credit.php
@@ -29,7 +29,7 @@
  * Plugin URI:        https://code.mundschenk.at/media-credit/
  * Description:       This plugin adds a "Credit" field to the media uploading and editing tool and inserts this credit when the images appear on your blog.
  * Version:           4.3.0-beta.1
- * Requires at least: 5.5
+ * Requires at least: 5.9
  * Requires PHP:      7.4
  * Author:            Peter Putzer
  * Author URI:        https://code.mundschenk.at/

--- a/media-credit.php
+++ b/media-credit.php
@@ -28,7 +28,7 @@
  * Plugin Name:       Media Credit
  * Plugin URI:        https://code.mundschenk.at/media-credit/
  * Description:       This plugin adds a "Credit" field to the media uploading and editing tool and inserts this credit when the images appear on your blog.
- * Version:           4.2.1
+ * Version:           4.3.0-beta.1
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            Peter Putzer

--- a/media-credit.php
+++ b/media-credit.php
@@ -29,7 +29,7 @@
  * Plugin URI:        https://code.mundschenk.at/media-credit/
  * Description:       This plugin adds a "Credit" field to the media uploading and editing tool and inserts this credit when the images appear on your blog.
  * Version:           4.3.0-beta.1
- * Requires at least: 5.4
+ * Requires at least: 5.5
  * Requires PHP:      7.4
  * Author:            Peter Putzer
  * Author URI:        https://code.mundschenk.at/

--- a/media-credit.php
+++ b/media-credit.php
@@ -29,7 +29,7 @@
  * Plugin URI:        https://code.mundschenk.at/media-credit/
  * Description:       This plugin adds a "Credit" field to the media uploading and editing tool and inserts this credit when the images appear on your blog.
  * Version:           4.3.0-beta.1
- * Requires at least: 5.2
+ * Requires at least: 5.4
  * Requires PHP:      7.4
  * Author:            Peter Putzer
  * Author URI:        https://code.mundschenk.at/

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,13 +6,14 @@
 	<!-- Set a description for this ruleset. -->
 	<description>A custom set of code standard rules to check for WordPress plugins.</description>
 
-	<config name="minimum_supported_wp_version" value="5.2"/>
+	<config name="minimum_supported_wp_version" value="5.9"/>
 	<config name="testVersion" value="7.4-"/>
 
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">
 		<exclude name="Generic.Functions.FunctionCallArgumentSpacing" />
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax" />
 	</rule>
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Media Credit ===
 Contributors: pputzer, sbressler
 Tags: media, image, images, credit, byline, author, user
-Tested up to: 5.8
+Tested up to: 6.2
 Stable tag: 4.2.1
 License: GPLv2 or later
 

--- a/tests/Media_Credit/Components/Shortcodes_Test.php
+++ b/tests/Media_Credit/Components/Shortcodes_Test.php
@@ -720,7 +720,7 @@ class Shortcodes_Test extends TestCase {
 				return empty( $value ) ? '' : "{$value} (SANITIZED TEXT)";
 			}
 		);
-		Functions\expect( 'esc_url_raw' )->once()->andReturnUsing(
+		Functions\expect( 'sanitize_url' )->once()->andReturnUsing(
 			function( $value ) {
 				return empty( $value ) ? '' : "{$value} (SANITIZED URL)";
 			}

--- a/tests/Media_Credit/Components/Shortcodes_Test.php
+++ b/tests/Media_Credit/Components/Shortcodes_Test.php
@@ -479,7 +479,7 @@ class Shortcodes_Test extends TestCase {
 		Functions\expect( 'current_theme_supports' )->once()->with( 'html5', 'caption' )->andReturn( $html5 );
 		Filters\expectApplied( 'img_caption_shortcode_width' )->once()->with( $width, $sanitized_atts, $content )->andReturn( $filtered_width );
 
-		Functions\expect( 'do_shortcode' )->once()->with( $content )->andReturn( '<img> with expanded shortcodes' );
+		Functions\expect( 'apply_shortcodes' )->once()->with( $content )->andReturn( '<img> with expanded shortcodes' );
 		$this->settings->shouldReceive( 'get' )->once()->with( Settings::SCHEMA_ORG_MARKUP )->andReturn( $schema_org );
 
 		$this->template->shouldReceive( 'get_partial' )->once()->with( '/public/partials/media-credit-shortcode.php', m::type( 'array' ) )->andReturn( $result );
@@ -511,7 +511,7 @@ class Shortcodes_Test extends TestCase {
 		Functions\expect( 'current_theme_supports' )->never();
 		Filters\expectApplied( 'img_caption_shortcode_width' )->never();
 
-		Functions\expect( 'do_shortcode' )->once()->with( $content )->andReturn( $filtered_content );
+		Functions\expect( 'apply_shortcodes' )->once()->with( $content )->andReturn( $filtered_content );
 		$this->settings->shouldReceive( 'get' )->never()->with( Settings::SCHEMA_ORG_MARKUP );
 
 		$this->assertSame( $filtered_content, $this->sut->media_credit_shortcode( $atts, $content ) );
@@ -547,7 +547,7 @@ class Shortcodes_Test extends TestCase {
 		Functions\expect( 'current_theme_supports' )->never();
 		Filters\expectApplied( 'img_caption_shortcode_width' )->never();
 
-		Functions\expect( 'do_shortcode' )->never();
+		Functions\expect( 'apply_shortcodes' )->never();
 		$this->settings->shouldReceive( 'get' )->never()->with( Settings::SCHEMA_ORG_MARKUP );
 
 		$this->assertSame( $pre_filter_shortcode, $this->sut->media_credit_shortcode( $atts, $content ) );

--- a/tests/Media_Credit/Core_Test.php
+++ b/tests/Media_Credit/Core_Test.php
@@ -363,7 +363,7 @@ class Core_Test extends TestCase {
 	}
 
 	/**
-	 * Test ::get_media_credit_url.
+	 * Test ::get_media_credit_url (with existing valid data).
 	 *
 	 * @covers ::get_media_credit_url
 	 */
@@ -377,28 +377,28 @@ class Core_Test extends TestCase {
 	}
 
 	/**
-	 * Test ::get_media_credit_data.
-	 *
-	 * @covers ::get_media_credit_data
-	 */
-	public function test_get_media_credit_data_string_result() {
-		$attachment_id = 4711;
-		$result        = 'nofollow';
-
-		Functions\expect( 'get_post_meta' )->once()->with( $attachment_id, Core::DATA_POSTMETA_KEY, true )->andReturn( $result );
-
-		$this->assertSame( [ $result ], $this->sut->get_media_credit_data( $attachment_id ) );
-	}
-
-	/**
-	 * Test ::get_media_credit_data.
+	 * Test ::get_media_credit_data when no post meta for the key exists.
 	 *
 	 * @covers ::get_media_credit_data
 	 */
 	public function test_get_media_credit_data_no_data() {
 		$attachment_id = 4711;
 
-		Functions\expect( 'get_post_meta' )->once()->with( $attachment_id, Core::DATA_POSTMETA_KEY, true )->andReturn( false );
+		Functions\expect( 'get_post_meta' )->once()->with( $attachment_id, Core::DATA_POSTMETA_KEY, true )->andReturn( [] );
+
+		$this->assertSame( [], $this->sut->get_media_credit_data( $attachment_id ) );
+	}
+
+	/**
+	 * Test ::get_media_credit_data when get_post_meta returns a string result
+	 * (which should not happen unless the DB has become corrupted).
+	 *
+	 * @covers ::get_media_credit_data
+	 */
+	public function test_get_media_credit_data_corrupted_database() {
+		$attachment_id = 4711;
+
+		Functions\expect( 'get_post_meta' )->once()->with( $attachment_id, Core::DATA_POSTMETA_KEY, true )->andReturn( 'the database has been corrupted' );
 
 		$this->assertSame( [], $this->sut->get_media_credit_data( $attachment_id ) );
 	}

--- a/tests/Media_Credit/Core_Test.php
+++ b/tests/Media_Credit/Core_Test.php
@@ -343,7 +343,7 @@ class Core_Test extends TestCase {
 	 */
 	public function test_sanitize_media_credit_meta_field( $meta_value, $meta_key, $object_type, $result ) {
 		Functions\expect( 'sanitize_text_field' )->atMost()->once()->with( $meta_value )->andReturn( self::SANITIZED_FREEFORM_CREDIT );
-		Functions\expect( 'esc_url_raw' )->atMost()->once()->with( $meta_value )->andReturn( self::SANITIZED_CREDIT_URL );
+		Functions\expect( 'sanitize_url' )->atMost()->once()->with( $meta_value )->andReturn( self::SANITIZED_CREDIT_URL );
 
 		$this->assertSame( $result, $this->sut->sanitize_media_credit_meta_field( $meta_value, $meta_key, $object_type ) );
 	}

--- a/tests/Media_Credit/Settings_Test.php
+++ b/tests/Media_Credit/Settings_Test.php
@@ -494,7 +494,7 @@ class Settings_Test extends \Media_Credit\Tests\TestCase {
 	public function test_get_fields() {
 		$site_name = 'My Cool Site';
 
-		Functions\expect( 'get_bloginfo' )->once()->with( 'name', 'display' )->andReturn( $site_name );
+		Functions\expect( 'get_bloginfo' )->once()->with( 'name', )->andReturn( $site_name );
 
 		$result = $this->sut->get_fields();
 
@@ -513,7 +513,7 @@ class Settings_Test extends \Media_Credit\Tests\TestCase {
 	public function test_get_defaults() {
 		$site_name = 'My Cool Site';
 
-		Functions\expect( 'get_bloginfo' )->once()->with( 'name', 'display' )->andReturn( $site_name );
+		Functions\expect( 'get_bloginfo' )->once()->with( 'name' )->andReturn( $site_name );
 
 		$result = $this->sut->get_defaults();
 

--- a/tests/Media_Credit/Tools/Author_Query_Test.php
+++ b/tests/Media_Credit/Tools/Author_Query_Test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Media Credit.
  *
- * Copyright 2021 Peter Putzer.
+ * Copyright 2021-2023 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,10 +26,8 @@
 
 namespace Media_Credit\Tests\Media_Credit\Tools;
 
-use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
-
 use Mockery as m;
 
 use Media_Credit\Tools\Author_Query;
@@ -72,7 +70,7 @@ class Author_Query_Test extends TestCase {
 		parent::set_up();
 
 		// Initialize helpers.
-		$this->cache = m::mock( Cache::Class );
+		$this->cache = m::mock( Cache::class );
 
 		// Create system-under-test.
 		$this->sut = m::mock( Author_Query::class, [ $this->cache ] )->makePartial()->shouldAllowMockingProtectedMethods();
@@ -84,7 +82,7 @@ class Author_Query_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$cache = m::mock( Cache::Class );
+		$cache = m::mock( Cache::class );
 
 		$mock = m::mock( Author_Query::class )->makePartial();
 		$mock->__construct( $cache );
@@ -160,17 +158,49 @@ class Author_Query_Test extends TestCase {
 		$this->assertSame( $result, $this->sut->get_authors() );
 	}
 
+
+	/**
+	 * Provides data for testing ::query.
+	 *
+	 * @return array
+	 */
+	public function provide_get_author_list_query_data() {
+		return [
+			[
+				'5.2',
+				[ 'who' => 'authors' ],
+			],
+			[
+				'5.8',
+				[ 'who' => 'authors' ],
+			],
+			[
+				'5.9-alpha',
+				[ 'capability' => 'edit_posts' ],
+			],
+			[
+				'5.9',
+				[ 'capability' => 'edit_posts' ],
+			],
+			[
+				'6.2',
+				[ 'capability' => 'edit_posts' ],
+			],
+		];
+	}
+
 	/**
 	 * Test ::get_author_list_query.
 	 *
 	 * @covers ::get_author_list_query
+	 *
+	 * @dataProvider provide_get_author_list_query_data
+	 *
+	 * @param string   $wp_version    The simulated WordPress version.
+	 * @param string[] $initial_query The expected initial author query.
 	 */
-	public function test_get_author_list_query() {
-		// Intermediary data.
-		$initial_query = [
-			'who' => 'authors',
-		];
-
+	public function test_get_author_list_query( $wp_version, $initial_query ) {
+		Functions\expect( 'get_bloginfo' )->once()->with( 'version' )->andReturn( $wp_version );
 		Filters\expectApplied( 'media_credit_author_list_query' )->once()->with( $initial_query )->andReturn( $initial_query );
 
 		$result = $this->sut->get_author_list_query();

--- a/tests/Media_Credit/Tools/Author_Query_Test.php
+++ b/tests/Media_Credit/Tools/Author_Query_Test.php
@@ -167,14 +167,6 @@ class Author_Query_Test extends TestCase {
 	public function provide_get_author_list_query_data() {
 		return [
 			[
-				'5.2',
-				[ 'who' => 'authors' ],
-			],
-			[
-				'5.8',
-				[ 'who' => 'authors' ],
-			],
-			[
 				'5.9-alpha',
 				[ 'capability' => 'edit_posts' ],
 			],
@@ -200,7 +192,7 @@ class Author_Query_Test extends TestCase {
 	 * @param string[] $initial_query The expected initial author query.
 	 */
 	public function test_get_author_list_query( $wp_version, $initial_query ) {
-		Functions\expect( 'get_bloginfo' )->once()->with( 'version' )->andReturn( $wp_version );
+		Functions\expect( 'get_bloginfo' )->atMost()->once()->with( 'version' )->andReturn( $wp_version );
 		Filters\expectApplied( 'media_credit_author_list_query' )->once()->with( $initial_query )->andReturn( $initial_query );
 
 		$result = $this->sut->get_author_list_query();

--- a/tests/Media_Credit_Template_Test.php
+++ b/tests/Media_Credit_Template_Test.php
@@ -196,7 +196,7 @@ class Media_Credit_Template_Test extends TestCase {
 		Functions\expect( '_deprecated_function' )->once()->with( m::type( 'string' ), m::type( 'string' ), m::type( 'string' ) );
 		$this->media_credit->shouldReceive( 'get_url' )->once()->with( $attachment_id )->andReturn( $result );
 
-		Functions\expect( 'esc_url_raw' )->once()->with( m::type( 'string' ) )->andReturnArg( 0 );
+		Functions\expect( 'sanitize_url' )->once()->with( m::type( 'string' ) )->andReturnArg( 0 );
 
 		$this->expectOutputString( $result );
 		$this->assertNull( \the_media_credit_url( $attachment_id ) );
@@ -212,7 +212,7 @@ class Media_Credit_Template_Test extends TestCase {
 		Functions\expect( '_doing_it_wrong' )->once()->with( m::type( 'string' ), m::type( 'string' ), '4.2.0' );
 
 		$this->media_credit->shouldReceive( 'get_url' )->never();
-		Functions\expect( 'esc_url_raw' )->never();
+		Functions\expect( 'sanitize_url' )->never();
 
 		$this->assertNull( \the_media_credit_url() );
 	}

--- a/uninstall.php
+++ b/uninstall.php
@@ -37,7 +37,7 @@ if ( ! \defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 // Make plugin file path available globally (even if we probably don't need it during uninstallaton).
 if ( ! \defined( 'MEDIA_CREDIT_PLUGIN_FILE' ) ) {
-	\define( 'MEDIA_CREDIT_PLUGIN_FILE', \dirname( __FILE__ ) . '/media-credit.php' );
+	\define( 'MEDIA_CREDIT_PLUGIN_FILE', __DIR__ . '/media-credit.php' );
 }
 if ( ! \defined( 'MEDIA_CREDIT_PLUGIN_PATH' ) ) {
 	\define( 'MEDIA_CREDIT_PLUGIN_PATH', __DIR__ );


### PR DESCRIPTION
- Requires at least WordPress 5.9.
- Uses capabilities for author queries on WordPress. Fixes #146.
- Updates JS presets.
- Settings initialization will use the unfiltered `raw` value from `get_bloginfo` to allow `wptexturize` be disabled more easily. Fixes #148.
- Bumps `Tested up to` to `6.2`.
- Bumps plugin version to `4.3.0-beta.1`
- Uses `apply_shortcodes` instead of legacy `do_shortcode` (requires at least WordPress 5.4).
- Uses `sanitize_url` instead of legacy `esc_url_raw` (requires at least WordPress 5.9).
- Updates WPCS to latest development version.